### PR TITLE
Add link to GoDoc documentation in README. closes #244

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   <a aria-label="Steampipe logo" href="https://steampipe.io">
     <img src="https://steampipe.io/images/steampipe_logo_wordmark_padding.svg" height="28">
   </a>
+  <a href="https://godoc.org/github.com/turbot/steampipe-plugin-sdk/plugin"><img src="https://img.shields.io/badge/go-documentation-blue.svg?style=flat-square" alt="Godoc" height=28></a>
   &nbsp;
   <a aria-label="License" href="LICENSE">
     <img alt="" src="https://img.shields.io/static/v1?label=license&message=Apache 2.0&style=for-the-badge&labelColor=777777&color=F3F1F0">


### PR DESCRIPTION
GoDoc standard reference: https://pkg.go.dev/github.com/tidwall/buntdb#section-readme