### PR TITLE
Avoid mutating Column objects which may be shared between tables. Use new QueryColumn object instead. Closes #259

### DIFF
--- a/plugin/column.go
+++ b/plugin/column.go
@@ -5,7 +5,8 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
 )
 
-// Column contains column data, in a format compatible with proto ColumnDefinition
+// Column is a struct representing a column defintion
+// it is not mutated and contains column data, in a format compatible with proto ColumnDefinition
 type Column struct {
 	// column name
 	Name string
@@ -16,11 +17,21 @@ type Column struct {
 	// explicitly specify the function which populates this data
 	// - this is only needed if any of the default hydrate functions wil NOT return this column
 	Hydrate HydrateFunc
-	// the name of the hydrate function which will be used to populate this column
-	// - this may be a default hydrate function
-	resolvedHydrateName string
 	// the default column value
 	Default interface{}
 	//  a list of transforms to generate the column value
 	Transform *transform.ColumnTransforms
+}
+
+// QueryColumn is struct storing column name and resolved hydrate name
+// this is used in the query data when the hydrate funciton has been resolved
+type QueryColumn struct {
+	*Column
+	// the name of the hydrate function which will be used to populate this column
+	// - this may be a default hydrate function
+	hydrateName string
+}
+
+func NewQueryColumn(column *Column, hydrateName string) *QueryColumn {
+	return &QueryColumn{column, hydrateName}
 }

--- a/plugin/table.go
+++ b/plugin/table.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"context"
-	"log"
 
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
@@ -58,8 +57,6 @@ type ListConfig struct {
 // NOTE2: this function also populates the resolvedHydrateName for each column (used to retrieve column values),
 // and the hydrateColumnMap (used to determine which columns to return)
 func (t *Table) requiredHydrateCalls(colsUsed []string, fetchType fetchType) []*HydrateCall {
-	log.Printf("[TRACE] requiredHydrateCalls, table '%s' fetchType %s colsUsed %v\n", t.Name, fetchType, colsUsed)
-
 	// what is the name of the fetch call (i.e. the get/list call)
 	fetchFunc := t.getFetchFunc(fetchType)
 	fetchCallName := helpers.GetFunctionName(fetchFunc)
@@ -90,8 +87,6 @@ func (t *Table) requiredHydrateCalls(colsUsed []string, fetchType fetchType) []*
 
 		// now update hydrateColumnMap
 		t.hydrateColumnMap[hydrateName] = append(t.hydrateColumnMap[hydrateName], column.Name)
-		// store the hydrate name in the column object
-		column.resolvedHydrateName = hydrateName
 	}
 	return requiredCallBuilder.Get()
 }


### PR DESCRIPTION
… 