### PR TITLE
Fix queries hanging when multiple scans are accessing the cache. Closes #391

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v4.1.2 [2022-08-25]
+_Bug fixes_
+* Fix queries sometimes hanging when multiple scans are accessing the cache. ([#391](https://github.com/turbot/steampipe-plugin-sdk/issues/391))
+
 ## v4.1.1 [2022-08-24]
 _Bug fixes_
 * Fix concurrent map access crash for Plugin.connectionCacheMap. ([#389](https://github.com/turbot/steampipe-plugin-sdk/issues/389))

--- a/query_cache/query_cache_pending.go
+++ b/query_cache/query_cache_pending.go
@@ -89,7 +89,7 @@ func (c *QueryCache) waitForPendingItem(ctx context.Context, pendingItem *pendin
 		log.Printf("[TRACE] waitForPendingItem transfer complete - trying cache again, (%s) pending item %p index item %p indexBucketKey: %s, item key %s", req.CallId, pendingItem, pendingItem.item, indexBucketKey, pendingItem.item.Key)
 
 		// now try to read from the cache again
-		_, err := c.getCachedQueryResultFromIndexItem(ctx, pendingItem.item, streamRowFunc)
+		err := c.getCachedQueryResultFromIndexItem(ctx, pendingItem.item, streamRowFunc)
 		if err != nil {
 			log.Printf("[WARN] waitForPendingItem (%s) - pending item %p, key %s, transferCompleteChan was signalled but getCachedResult returned error: %v", req.CallId, pendingItem, pendingItem.item.Key, err)
 			// if the data is still not in the cache, create a pending item

--- a/version/version.go
+++ b/version/version.go
@@ -11,12 +11,12 @@ import (
 var ProtocolVersion int64 = 20220201
 
 // Version is the main version number that is being run at the moment.
-var version = "4.1.1"
+var version = "4.1.2"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release
 // such as "dev" (in development), "beta", "rc1", etc.
-var prerelease = ""
+var prerelease = "rc.0"
 
 // semVer is an instance of version.Version. This has the secondary
 // benefit of verifying during tests and init time that our version is a


### PR DESCRIPTION
remove queryCache.streamLock