### PR TITLE
feat: NullIfEmptySlice transform

### DIFF
--- a/plugin/transform/primitives.go
+++ b/plugin/transform/primitives.go
@@ -17,7 +17,7 @@ import (
 	"github.com/turbot/go-kit/types"
 )
 
-///////////////////////
+// /////////////////////
 // Transform primitives
 // predefined transform functions that may be chained together
 
@@ -203,6 +203,19 @@ func NullIfZeroValue(_ context.Context, d *TransformData) (interface{}, error) {
 		return d.Value, nil
 	}
 	if helpers.IsZero(v) {
+		return nil, nil
+	}
+	return d.Value, nil
+}
+
+// NullIfEmptySliceValue returns nil if the input Value is an empty slice/array
+func NullIfEmptySliceValue(_ context.Context, d *TransformData) (interface{}, error) {
+	if d.Value == nil {
+		return nil, nil
+	}
+	v := helpers.DereferencePointer(d.Value)
+	b, l := reflect.TypeOf(v).Kind() == reflect.Slice, reflect.ValueOf(v).Len()
+	if b && l == 0 {
 		return nil, nil
 	}
 	return d.Value, nil

--- a/plugin/transform/primitives_test.go
+++ b/plugin/transform/primitives_test.go
@@ -793,6 +793,20 @@ Statement:
 		function: StringArrayToMap,
 		expected: "ERROR",
 	},
+	"NullIfEmptySlice array": {
+		d: &TransformData{
+			Value: []testStruct{{a: "A", b: "B"}, {a: "1", b: "2"}},
+		},
+		function: NullIfEmptySliceValue,
+		expected: []testStruct{{a: "A", b: "B"}, {a: "1", b: "2"}},
+	},
+	"NullIfEmptySlice nil": {
+		d: &TransformData{
+			Value: []testStruct{},
+		},
+		function: NullIfEmptySliceValue,
+		expected: nil,
+	},
 }
 
 func TestTransformFunctions(t *testing.T) {

--- a/plugin/transform/transform.go
+++ b/plugin/transform/transform.go
@@ -95,3 +95,9 @@ func (t *ColumnTransforms) NullIfZero() *ColumnTransforms {
 	t.Transforms = append(t.Transforms, &TransformCall{Transform: NullIfZeroValue})
 	return t
 }
+
+// NullIfEmptySlice returns nil if the input value is an empty slice/array
+func (t *ColumnTransforms) NullIfEmptySlice() *ColumnTransforms {
+	t.Transforms = append(t.Transforms, &TransformCall{Transform: NullIfEmptySliceValue})
+	return t
+}


### PR DESCRIPTION
I wrote a [transform function for another member of the community](https://steampipe.slack.com/archives/C044P668806/p1672483705596409?thread_ts=1672408854.770969&cid=C044P668806) to help them display empty slices as `null` in their query , they suggested I submit it as a PR to the SDK, so here's an attempt 😉

(also apologies for the space insertion on L20, `go fmt` did it 😄)