### PR TITLE
If an empty Matrix is returned from MatrixItemFunc, fetch function should not be called. Closes #496

### DIFF
--- a/plugin/table_fetch.go
+++ b/plugin/table_fetch.go
@@ -452,7 +452,7 @@ func (t *Table) doList(ctx context.Context, queryData *QueryData, listCall Hydra
 	rd := newRowData(queryData, nil)
 
 	// if a matrix is defined, run listForEach
-	if len(queryData.Matrix) > 0 {
+	if queryData.Matrix != nil {
 		log.Printf("[TRACE] doList: matrix len %d - calling  listForEach", len(queryData.Matrix))
 		t.listForEach(ctx, queryData, listCall)
 	} else {


### PR DESCRIPTION
…