### PR TITLE
feat: add support for like, not like, ilike and not ilike operators in List hydrate functions

### DIFF
--- a/plugin/key_column.go
+++ b/plugin/key_column.go
@@ -18,6 +18,28 @@ const (
 	AnyOf    = "any_of"
 )
 
+// GetValidOperators returns the list of operators which are valid in the context of KeyColumn
+func GetValidOperators() []string {
+	return []string{
+		quals.QualOperatorEqual,
+		quals.QualOperatorNotEqual,
+		quals.QualOperatorLess,
+		quals.QualOperatorLessOrEqual,
+		quals.QualOperatorGreater,
+		quals.QualOperatorGreaterOrEqual,
+		quals.QualOperatorLike,
+		quals.QualOperatorNotLike,
+		quals.QualOperatorILike,
+		quals.QualOperatorNotILike,
+		quals.QualOperatorRegex,
+		quals.QualOperatorNotRegex,
+		quals.QualOperatorIRegex,
+		quals.QualOperatorNotIRegex,
+		quals.QualOperatorIsNull,
+		quals.QualOperatorIsNotNull,
+	}
+}
+
 // KeyColumn is a struct representing the definition of a column used to filter and Get and List calls.
 //
 // At least one key column must be defined for a Get call. They are optional for List calls.
@@ -122,7 +144,7 @@ func (k *KeyColumn) Validate() []string {
 	// first set default operator and convert "!=" to "<>"
 	k.InitialiseOperators()
 	// ensure operators are valid
-	validOperators := []string{"=", "<>", "<", "<=", ">", ">=", "~~", "!~~", "~~*", "!~~*", "~", "~*", "!~", "!~*", quals.QualOperatorIsNull, quals.QualOperatorIsNotNull}
+	validOperators := GetValidOperators()
 	validRequire := []string{Required, Optional, AnyOf}
 	validCacheMatch := []string{query_cache.CacheMatchSubset, query_cache.CacheMatchExact, ""}
 	var res []string

--- a/plugin/key_column.go
+++ b/plugin/key_column.go
@@ -24,7 +24,7 @@ const (
 //
 // # Operators
 //
-// This property specifies the accepted operators (from a possible set: "=", "<>", "<", "<=", ">", ">=")
+// This property specifies the accepted operators (from a possible set: "=", "<>", "<", "<=", ">", ">=", "~~", "!~~", "~~*", "!~~*")
 //
 // # Require
 //
@@ -122,7 +122,7 @@ func (k *KeyColumn) Validate() []string {
 	// first set default operator and convert "!=" to "<>"
 	k.InitialiseOperators()
 	// ensure operators are valid
-	validOperators := []string{"=", "<>", "<", "<=", ">", ">=", quals.QualOperatorIsNull, quals.QualOperatorIsNotNull}
+	validOperators := []string{"=", "<>", "<", "<=", ">", ">=", "~~", "!~~", "~~*", "!~~*", quals.QualOperatorIsNull, quals.QualOperatorIsNotNull}
 	validRequire := []string{Required, Optional, AnyOf}
 	validCacheMatch := []string{query_cache.CacheMatchSubset, query_cache.CacheMatchExact, ""}
 	var res []string

--- a/plugin/key_column.go
+++ b/plugin/key_column.go
@@ -24,7 +24,7 @@ const (
 //
 // # Operators
 //
-// This property specifies the accepted operators (from a possible set: "=", "<>", "<", "<=", ">", ">=", "~~", "!~~", "~~*", "!~~*")
+// This property specifies the accepted operators (from a possible set: "=", "<>", "<", "<=", ">", ">=", "~~", "!~~", "~~*", "!~~*", "~", "~*", "!~", "!~*")
 //
 // # Require
 //
@@ -122,7 +122,7 @@ func (k *KeyColumn) Validate() []string {
 	// first set default operator and convert "!=" to "<>"
 	k.InitialiseOperators()
 	// ensure operators are valid
-	validOperators := []string{"=", "<>", "<", "<=", ">", ">=", "~~", "!~~", "~~*", "!~~*", quals.QualOperatorIsNull, quals.QualOperatorIsNotNull}
+	validOperators := []string{"=", "<>", "<", "<=", ">", ">=", "~~", "!~~", "~~*", "!~~*", "~", "~*", "!~", "!~*", quals.QualOperatorIsNull, quals.QualOperatorIsNotNull}
 	validRequire := []string{Required, Optional, AnyOf}
 	validCacheMatch := []string{query_cache.CacheMatchSubset, query_cache.CacheMatchExact, ""}
 	var res []string

--- a/plugin/key_column_qual_map.go
+++ b/plugin/key_column_qual_map.go
@@ -92,7 +92,7 @@ func (m KeyColumnQualMap) GetUnsatisfiedKeyColumns(columns KeyColumnSlice) KeyCo
 }
 
 // ToQualMap converts the map into a simpler map of column to []Quals
-// this is used in the TraansformData
+// this is used in the TransformData
 // (needed to avoid the transform package needing to reference plugin)
 func (m KeyColumnQualMap) ToQualMap() map[string]quals.QualSlice {
 	var res = make(map[string]quals.QualSlice)

--- a/plugin/quals/qual.go
+++ b/plugin/quals/qual.go
@@ -5,8 +5,24 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 )
 
-const QualOperatorIsNull = "is null"
-const QualOperatorIsNotNull = "is not null"
+const (
+	QualOperatorEqual          = "="
+	QualOperatorNotEqual       = "<>"
+	QualOperatorLess           = "<"
+	QualOperatorLessOrEqual    = "<="
+	QualOperatorGreater        = ">"
+	QualOperatorGreaterOrEqual = ">="
+	QualOperatorLike           = "~~"
+	QualOperatorNotLike        = "!~~"
+	QualOperatorILike          = "~~*"
+	QualOperatorNotILike       = "!~~*"
+	QualOperatorRegex          = "~"
+	QualOperatorNotRegex       = "!~"
+	QualOperatorIRegex         = "~*"
+	QualOperatorNotIRegex      = "!~*"
+	QualOperatorIsNull         = "is null"
+	QualOperatorIsNotNull      = "is not null"
+)
 
 // Qual is a struct which represents a database qual in a more easily digestible form that proto.Qual
 type Qual struct {


### PR DESCRIPTION
This PR adds support for passing `like` (`~~`), `not like` (`!~~`), `ilike` (`~~*`) and `not ilike` (`!~~*`) [PostgreSQL operators](https://www.postgresql.org/docs/14/functions-matching.html#FUNCTIONS-LIKE) as qualifiers to List hydrate functions, allowing them to construct API specific filters.

Use case with the Vault plugin is discussed in Slack: https://steampipe.slack.com/archives/C044P668806/p1674495168279979?thread_ts=1674488786.838089&cid=C044P668806