### PR TITLE
Update cache pending item implementation - cache requests should subscribe to pending items and stream them as the data is received rather than waiting for the item to complete. Closes #564

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -384,6 +384,9 @@ func (p *Plugin) executeForConnection(ctx context.Context, req *proto.ExecuteReq
 			log.Printf("[TRACE] queryCache.Get took %.1fs: (%s),", getDuration.Seconds(), connectionCallId)
 		}
 
+
+
+
 		// so the cache call failed, with either a cache-miss or other error
 		if query_cache.IsCacheMiss(cacheErr) {
 			log.Printf("[TRACE] cache MISS")
@@ -400,6 +403,12 @@ func (p *Plugin) executeForConnection(ctx context.Context, req *proto.ExecuteReq
 	} else {
 		log.Printf("[INFO] Cache DISABLED connectionCallId: %s", connectionCallId)
 	}
+
+	// TODO
+	// if partialCacheHit{
+	// calc missing columns, build new query data
+	// queryData = partialCacheHitQueryData()
+	//
 
 	// asyncronously fetch items
 	log.Printf("[TRACE] calling fetchItems, table: %s, matrixItem: %v, limit: %d,  connectionCallId: %s\"", table.Name, queryData.Matrix, limit, connectionCallId)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -330,7 +330,7 @@ func (p *Plugin) executeForConnection(ctx context.Context, req *proto.ExecuteReq
 
 	// get the matrix item
 	log.Printf("[TRACE] GetMatrixItem")
-	var matrixItem []map[string]interface{}
+	var matrixItem []map[string]any
 	if table.GetMatrixItem != nil {
 		matrixItem = table.GetMatrixItem(ctx, connectionData.Connection)
 	}
@@ -384,9 +384,6 @@ func (p *Plugin) executeForConnection(ctx context.Context, req *proto.ExecuteReq
 			log.Printf("[TRACE] queryCache.Get took %.1fs: (%s),", getDuration.Seconds(), connectionCallId)
 		}
 
-
-
-
 		// so the cache call failed, with either a cache-miss or other error
 		if query_cache.IsCacheMiss(cacheErr) {
 			log.Printf("[TRACE] cache MISS")
@@ -403,12 +400,6 @@ func (p *Plugin) executeForConnection(ctx context.Context, req *proto.ExecuteReq
 	} else {
 		log.Printf("[INFO] Cache DISABLED connectionCallId: %s", connectionCallId)
 	}
-
-	// TODO
-	// if partialCacheHit{
-	// calc missing columns, build new query data
-	// queryData = partialCacheHitQueryData()
-	//
 
 	// asyncronously fetch items
 	log.Printf("[TRACE] calling fetchItems, table: %s, matrixItem: %v, limit: %d,  connectionCallId: %s\"", table.Name, queryData.Matrix, limit, connectionCallId)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -349,7 +349,7 @@ func (p *Plugin) executeForConnection(ctx context.Context, req *proto.ExecuteReq
 	cacheRequest := &query_cache.CacheRequest{
 		Table:          table.Name,
 		QualMap:        cacheQualMap,
-		Columns:        queryContext.Columns,
+		Columns:        queryData.getColumnNames(), // all column names returned by the required hydrate functions
 		Limit:          limit,
 		ConnectionName: connectionName,
 		TtlSeconds:     queryContext.CacheTTL,
@@ -397,12 +397,6 @@ func (p *Plugin) executeForConnection(ctx context.Context, req *proto.ExecuteReq
 		}
 
 		log.Printf("[INFO] queryCacheGet returned CACHE MISS (%s)", connectionCallId)
-
-		// NOTE: update the cache request to include ALL the columns which will be fetched, not just those requested
-		// this means subsequent queries requesting other columns from same hydrate func(s) can be served from the cache
-		cacheRequest.Columns = queryData.getColumnNames()
-
-		p.queryCache.StartSet(ctx, cacheRequest)
 	} else {
 		log.Printf("[INFO] Cache DISABLED connectionCallId: %s", connectionCallId)
 	}

--- a/query_cache/cache_request.go
+++ b/query_cache/cache_request.go
@@ -18,7 +18,6 @@ type CacheRequest struct {
 
 	// used for set requests
 	rows      []*sdkproto.Row
-	raws      []any
 	rowIndex  int
 	pageCount int64
 	err       error

--- a/query_cache/cache_request.go
+++ b/query_cache/cache_request.go
@@ -18,6 +18,7 @@ type CacheRequest struct {
 
 	// used for set requests
 	rows      []*sdkproto.Row
+	raws      []any
 	rowIndex  int
 	pageCount int64
 	err       error

--- a/query_cache/cache_request.go
+++ b/query_cache/cache_request.go
@@ -32,6 +32,14 @@ func (req *CacheRequest) getPageResultKey() string {
 	return getPageKey(req.resultKeyRoot, req.pageCount-1)
 }
 
+func (req *CacheRequest) getPrevPageResultKeys() []string {
+	var res []string
+	for i := 0; i < int(req.pageCount); i++ {
+		res = append(res, getPageKey(req.resultKeyRoot, req.pageCount-1))
+	}
+	return res
+}
+
 func (req *CacheRequest) getRows() []*sdkproto.Row {
 	if req.rowIndex == 0 {
 		return nil

--- a/query_cache/pending_index_item.go
+++ b/query_cache/pending_index_item.go
@@ -2,10 +2,11 @@ package query_cache
 
 import (
 	"fmt"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"log"
 	"strings"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 )
 
 // pendingIndexBucket contains index items for all pending cache results for a given table and qual set
@@ -57,7 +58,7 @@ func (b *pendingIndexBucket) delete(pendingItem *pendingIndexItem) {
 func (b *pendingIndexBucket) String() any {
 	var sb strings.Builder
 	for itemKey, item := range b.Items {
-		sb.WriteString(fmt.Sprintf("item: %p, count: %d, key:%s\n", item, item.count, itemKey))
+		sb.WriteString(fmt.Sprintf("item: %p, key:%s\n", item, itemKey))
 	}
 	return sb.String()
 }
@@ -65,9 +66,7 @@ func (b *pendingIndexBucket) String() any {
 // pendingIndexItem stores the columns and cached index for a single pending query result
 // note - this index item it tied to a specific table and set of quals
 type pendingIndexItem struct {
-	item *IndexItem
-	// used for logging purposes only (as we cannot access wait groups count)
-	count  int
+	item   *IndexItem
 	err    error
 	callId string
 }

--- a/query_cache/query_cache_pending.go
+++ b/query_cache/query_cache_pending.go
@@ -4,16 +4,9 @@ import (
 	"context"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc"
 	"log"
-	"time"
-
-	"github.com/turbot/steampipe-plugin-sdk/v5/error_helpers"
-	sdkproto "github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/telemetry"
 )
 
-const pendingQueryTimeout = 20 * time.Second
-
-func (c *QueryCache) getPendingResultItem(indexBucketKey string, req *CacheRequest) *pendingIndexItem {
+func (c *QueryCache) getPendingResultItem(ctx context.Context, indexBucketKey string, req *CacheRequest) *pendingIndexItem {
 	log.Printf("[TRACE] getPendingResultItem indexBucketKey %s, columns %v, limit %d", indexBucketKey, req.Columns, req.Limit)
 	//c.logPending(req)
 
@@ -34,8 +27,6 @@ func (c *QueryCache) getPendingResultItem(indexBucketKey string, req *CacheReque
 		pendingItems, _ = c.getPendingItemSatisfyingRequest(indexBucketKey, req)
 		if len(pendingItems) == 0 {
 			log.Printf("[TRACE] no pending index item - add pending result, indexBucketKey %s", indexBucketKey)
-			// add a pending result so anyone else asking for this data will wait the fetch to complete
-			c.addPendingResult(indexBucketKey, req)
 			// return nil (i.e. cache miss)
 			return nil
 		}
@@ -62,7 +53,7 @@ func (c *QueryCache) getPendingItemSatisfyingRequest(indexBucketKey string, req 
 }
 
 // this must be called inside a lock
-func (c *QueryCache) getPendingItemSatisfiedByRequest(indexBucketKey string, req *CacheRequest) ([]*pendingIndexItem, *pendingIndexBucket) {
+func (c *QueryCache) getPendingItemResolvedByRequest(indexBucketKey string, req *CacheRequest) ([]*pendingIndexItem, *pendingIndexBucket) {
 	keyColumns := c.getKeyColumnsForTable(req.Table, req.ConnectionName)
 
 	// is there a pending index bucket for this query
@@ -76,90 +67,10 @@ func (c *QueryCache) getPendingItemSatisfiedByRequest(indexBucketKey string, req
 	return nil, nil
 }
 
-func (c *QueryCache) waitForPendingItem(ctx context.Context, pendingItem *pendingIndexItem, indexBucketKey string, req *CacheRequest, streamRowFunc func(row *sdkproto.Row)) (err error) {
-	ctx, span := telemetry.StartSpan(ctx, c.pluginName, "QueryCache.waitForPendingItem (%s)", req.Table)
+func (c *QueryCache) addPendingResult(ctx context.Context, indexBucketKey string, req *CacheRequest) {
+	// call start set to add the request to the setRequest map
+	c.startSet(ctx, req)
 
-	defer span.End()
-
-	transferCompleteChan := make(chan bool, 1)
-	errChan := make(chan error, 1)
-	go func() {
-		log.Printf("[TRACE] waitForPendingItem (%s) %p indexBucketKey: %s, item key %s", req.CallId, pendingItem, indexBucketKey, pendingItem.item.Key)
-		// if pendingItem.Wait() returns an error it means the query we are waiting for failed - we should fail as well
-		err := pendingItem.Wait()
-		log.Printf("[TRACE] pendingItem.Wait() returned, error: %v", err)
-		if err != nil {
-			if !error_helpers.IsContextCancelledError(err) {
-				log.Printf("[WARN] wrapping error %v in a QueryError and returning", err)
-				// wrap the error in a query error to the calling code realizes this was not just a cache error
-				err = error_helpers.NewQueryError(err)
-			}
-			errChan <- err
-			return
-		}
-
-		log.Printf("[TRACE] pending item COMPLETE (%s) %p indexBucketKey: %s, item key %s", req.CallId, pendingItem, indexBucketKey, pendingItem.item.Key)
-		close(transferCompleteChan)
-	}()
-
-	select {
-	case <-ctx.Done():
-		log.Printf("[TRACE] waitForPendingItem aborting as context cancelled")
-		err = ctx.Err()
-
-	case <-time.After(pendingQueryTimeout):
-		log.Printf("[WARN] waitForPendingItem timed out waiting for pending transfer (%s) %p indexBucketKey: %s, item key %s", req.CallId, pendingItem, indexBucketKey, pendingItem.item.Key)
-
-		// remove the pending result from the map
-		// acquire a Write lock to pendingData map
-		c.pendingDataLock.Lock()
-		//c.logPending(req)
-
-		// if the pending bucket still exists, delete the pending item
-		//( it may not exists  if the pending item jhhas actually finished and we just missed the event)
-		if pendingBucket, ok := c.pendingData[indexBucketKey]; ok {
-			// c.pendingData[indexBucketKey] may be nil
-			// remove the pending item - it has timed out
-			pendingBucket.delete(pendingItem)
-		}
-		// add a new pending item, within the lock
-		c.addPendingResult(indexBucketKey, req)
-		c.pendingDataLock.Unlock()
-
-		log.Printf("[TRACE] added new pending item, returning cache miss (%s)", req.CallId)
-		// return cache miss error to force a fetch
-		err = CacheMissError{}
-
-	case <-transferCompleteChan:
-		log.Printf("[TRACE] waitForPendingItem transfer complete - trying cache again, (%s) pending item %p index item %p indexBucketKey: %s, item key %s", req.CallId, pendingItem, pendingItem.item, indexBucketKey, pendingItem.item.Key)
-
-		// now try to read from the cache again
-		// NOTE: use same error variable so we can return it
-		err = c.getCachedQueryResultFromIndexItem(ctx, pendingItem.item, streamRowFunc)
-		if err != nil {
-			log.Printf("[WARN] waitForPendingItem (%s) - pending item %p, key '%s', transferCompleteChan was signalled but getCachedResult returned error: %v", req.CallId, pendingItem, pendingItem.item.Key, err)
-			// if the data is still not in the cache, create a pending item
-			if IsCacheMiss(err) {
-				log.Printf("[WARN] waitForPendingItem item still not in the cache - add pending item, (%s) indexBucketKey: %s, item key %s", req.CallId, indexBucketKey, pendingItem.item.Key)
-				// acquire a Write lock to pendingData map
-				c.pendingDataLock.Lock()
-				// add a new pending item, within the lock
-				c.addPendingResult(indexBucketKey, req)
-				c.pendingDataLock.Unlock()
-			}
-		} else {
-			log.Printf("[TRACE] waitForPendingItem retrieved from cache, (%s) indexBucketKey: %s, item key %s", req.CallId, indexBucketKey, pendingItem.item.Key)
-		}
-	case err = <-errChan:
-		if !error_helpers.IsContextCancelledError(err) {
-			log.Printf("[WARN] waitForPendingItem returned error %s", err.Error())
-		}
-		// fall through
-	}
-	return err
-}
-
-func (c *QueryCache) addPendingResult(indexBucketKey string, req *CacheRequest) {
 	// this must be called within a pendingDataLock Write Lock
 	log.Printf("[TRACE] addPendingResult (%s) indexBucketKey %s, columns %v, limit %d", req.CallId, indexBucketKey, req.Columns, req.Limit)
 
@@ -197,7 +108,7 @@ func (c *QueryCache) pendingItemComplete(req *CacheRequest, err error) {
 	c.pendingDataLock.RLock()
 	// do we have a pending items
 	// the may be more than one pending item which is satisfied by this request - clear them all
-	completedPendingItems, _ := c.getPendingItemSatisfiedByRequest(indexBucketKey, req)
+	completedPendingItems, _ := c.getPendingItemResolvedByRequest(indexBucketKey, req)
 	// release read lock
 	c.pendingDataLock.RUnlock()
 
@@ -210,7 +121,7 @@ func (c *QueryCache) pendingItemComplete(req *CacheRequest, err error) {
 		defer c.pendingDataLock.Unlock()
 
 		// check again for completed items (in case anyone else grabbed a Write lock before us)
-		completedPendingItems, pendingIndexBucket := c.getPendingItemSatisfyingRequest(indexBucketKey, req)
+		completedPendingItems, pendingIndexBucket := c.getPendingItemResolvedByRequest(indexBucketKey, req)
 		for _, pendingItem := range completedPendingItems {
 			// remove pending item from the parent pendingIndexBucket (BEFORE updating the index item cache key)
 			delete(pendingIndexBucket.Items, pendingItem.item.Key)
@@ -222,8 +133,6 @@ func (c *QueryCache) pendingItemComplete(req *CacheRequest, err error) {
 			pendingItem.item.Key = req.resultKeyRoot
 
 			log.Printf("[TRACE] found completed pending item (%s) %p, key %s - removing from map as it is complete", req.CallId, pendingItem, pendingItem.item.Key)
-			// unlock the item passing err (which may be nil)
-			pendingItem.Unlock(err)
 			log.Printf("[TRACE] deleted from pending, (%s) len %d", req.CallId, len(pendingIndexBucket.Items))
 		}
 		if len(pendingIndexBucket.Items) == 0 {

--- a/query_cache/set_request.go
+++ b/query_cache/set_request.go
@@ -1,21 +1,23 @@
 package query_cache
 
-import sdkproto "github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+import (
+	sdkproto "github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"sync"
+)
 
 type setRequest struct {
 	*CacheRequest
 	// other cache requests who are subscribing to this data
 	subscribers []func(row *sdkproto.Row)
+	mut         sync.RWMutex
 }
 
-func (r setRequest) subscribe(subscriber func(row *sdkproto.Row)) {
+func (r *setRequest) subscribe(subscriber func(row *sdkproto.Row)) {
 	r.subscribers = append(r.subscribers, subscriber)
 }
 
-func (r setRequest) streamToSubscribers(rows []*sdkproto.Row) {
+func (r *setRequest) streamToSubscribers(row *sdkproto.Row) {
 	for _, streamFunc := range r.subscribers {
-		for _, row := range rows {
-			streamFunc(row)
-		}
+		streamFunc(row)
 	}
 }

--- a/query_cache/set_request.go
+++ b/query_cache/set_request.go
@@ -1,0 +1,21 @@
+package query_cache
+
+import sdkproto "github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+
+type setRequest struct {
+	*CacheRequest
+	// other cache requests who are subscribing to this data
+	subscribers []func(row *sdkproto.Row)
+}
+
+func (r setRequest) subscribe(subscriber func(row *sdkproto.Row)) {
+	r.subscribers = append(r.subscribers, subscriber)
+}
+
+func (r setRequest) streamToSubscribers(rows []*sdkproto.Row) {
+	for _, streamFunc := range r.subscribers {
+		for _, row := range rows {
+			streamFunc(row)
+		}
+	}
+}


### PR DESCRIPTION
When making cache request, update request to include ALL columns which will be returned, not just columns requested. 


This will allow pending item code to match in cases where a different column in the same hydrate function is requested


#566