### PR TITLE
Fix matrix get() - rate limiters were not initialised because we were using parent query data not matrix query data #632

### DIFF
--- a/error_helpers/utils.go
+++ b/error_helpers/utils.go
@@ -2,6 +2,7 @@ package error_helpers
 
 import (
 	"fmt"
+	"golang.org/x/exp/maps"
 	"strings"
 )
 
@@ -31,14 +32,16 @@ func CombineErrorsWithPrefix(prefix string, errors ...error) error {
 		}
 	}
 
-	combinedErrorString := []string{prefix}
+	// put into map to dedupe
+	combinedErrorStrings := map[string]struct{}{prefix: {}}
 	for _, e := range errors {
 		if e == nil {
 			continue
 		}
-		combinedErrorString = append(combinedErrorString, e.Error())
+		combinedErrorStrings[e.Error()] = struct{}{}
 	}
-	return fmt.Errorf(strings.Join(combinedErrorString, "\n\t"))
+
+	return fmt.Errorf(strings.Join(maps.Keys(combinedErrorStrings), "\n\t"))
 }
 
 func CombineErrors(errors ...error) error {

--- a/plugin/plugin_grpc.go
+++ b/plugin/plugin_grpc.go
@@ -348,7 +348,7 @@ func (p *Plugin) setRateLimiters(request *proto.SetRateLimitersRequest) (err err
 	for _, pd := range request.Definitions {
 		d, err := rate_limiter.DefinitionFromProto(pd)
 		if err != nil {
-			errors = append(errors, sperr.WrapWithMessage(err, "failed to create rate limiter %s from config", err))
+			errors = append(errors, sperr.WrapWithMessage(err, "failed to create rate limiter '%s' from config", pd.Name))
 			continue
 		}
 

--- a/plugin/plugin_rate_limiter.go
+++ b/plugin/plugin_rate_limiter.go
@@ -58,7 +58,7 @@ func (p *Plugin) getRateLimitersForScopeValues(scopeValues map[string]string) ([
 	p.rateLimiterDefsMut.RLock()
 	defer p.rateLimiterDefsMut.RUnlock()
 
-	// NOTE: use rateLimiterLookup NOT the public RateLimiter property.
+	// NOTE: use resolvedRateLimiterDefs NOT the public RateLimiter property.
 	// This is to ensure config overrides are respected
 	for _, l := range p.resolvedRateLimiterDefs {
 		// build a filtered map of just the scope values required for this limiter

--- a/rate_limiter/scope_filter.go
+++ b/rate_limiter/scope_filter.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"github.com/danwakefield/fnmatch"
 	"github.com/turbot/steampipe-plugin-sdk/v5/filter"
+	"github.com/turbot/steampipe-plugin-sdk/v5/sperr"
+	"log"
 	"strings"
 )
 
@@ -15,7 +17,8 @@ type scopeFilter struct {
 func newScopeFilter(raw string) (*scopeFilter, error) {
 	parsed, err := filter.Parse("", []byte(raw))
 	if err != nil {
-		return nil, err
+		log.Printf("err %v", err)
+		return nil, sperr.New("failed to parse 'where' property: %s", err.Error())
 	}
 
 	res := &scopeFilter{


### PR DESCRIPTION
 Improve rate limiter 'where' parse errors
 Fix getForEachMatrixItem to create a rowData for each matrix item