### PR TITLE
Fix memoized hydrate funcs appearing as `func1` in _ctx

### DIFF
--- a/plugin/get_config.go
+++ b/plugin/get_config.go
@@ -75,6 +75,7 @@ type GetConfig struct {
 	// Deprecated: use IgnoreConfig
 	ShouldIgnoreError ErrorPredicate
 	MaxConcurrency    int
+	named             namedHydrateFunc
 }
 
 // initialise the GetConfig
@@ -122,6 +123,10 @@ func (c *GetConfig) initialise(table *Table) {
 		c.IgnoreConfig.DefaultTo(table.DefaultIgnoreConfig)
 	}
 	log.Printf("[TRACE] GetConfig.initialise complete: RetryConfig: %s, IgnoreConfig: %s", c.RetryConfig.String(), c.IgnoreConfig.String())
+
+	// populate the namedHydrateFunc hydrate func
+	c.named = newNamedHydrateFunc(c.Hydrate)
+
 }
 
 func (c *GetConfig) Validate(table *Table) []string {
@@ -164,4 +169,8 @@ func (c *GetConfig) Validate(table *Table) []string {
 	}
 
 	return validationErrors
+}
+
+func (c *GetConfig) namedHydrateFunc() namedHydrateFunc {
+	return c.named
 }

--- a/plugin/hydrate_cache.go
+++ b/plugin/hydrate_cache.go
@@ -18,13 +18,20 @@ var memoizedNameMapLock sync.RWMutex
 var memoizedHydrateFunctionsPending = make(map[string]*sync.WaitGroup)
 var memoizedHydrateLock sync.RWMutex
 
-func getMemoizedFuncName(f HydrateFunc) (string, bool) {
+// return the function name
+// if this function has been memoized, return the underlying function
+func getOriginalFuncName(f HydrateFunc) string {
 	memoizedNameMapLock.RLock()
 	// check if this is a memoized function, if so get the original name
 	p := reflect.ValueOf(f).Pointer()
-	originalName, isMemoized := memoizedNameMap[p]
+	name, isMemoized := memoizedNameMap[p]
 	memoizedNameMapLock.RUnlock()
-	return originalName, isMemoized
+
+	if !isMemoized {
+		name = helpers.GetFunctionName(f)
+	}
+
+	return name
 }
 
 func setMemoizedFuncName(memoizedFunc, originalFunc HydrateFunc) {

--- a/plugin/hydrate_cache.go
+++ b/plugin/hydrate_cache.go
@@ -4,17 +4,39 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"reflect"
 	"sync"
 	"time"
 
 	"github.com/turbot/go-kit/helpers"
 )
 
+// map of memoized functions to the original function name
+var memoizedNameMap = make(map[uintptr]string)
+var memoizedNameMapLock sync.RWMutex
+
 var memoizedHydrateFunctionsPending = make(map[string]*sync.WaitGroup)
 var memoizedHydrateLock sync.RWMutex
 
+func getMemoizedFuncName(f HydrateFunc) (string, bool) {
+	memoizedNameMapLock.RLock()
+	// check if this is a memoized function, if so get the original name
+	p := reflect.ValueOf(f).Pointer()
+	originalName, isMemoized := memoizedNameMap[p]
+	memoizedNameMapLock.RUnlock()
+	return originalName, isMemoized
+}
+
+func setMemoizedFuncName(memoizedFunc, originalFunc HydrateFunc) {
+	// add to map
+	memoizedNameMapLock.Lock()
+	p := reflect.ValueOf(memoizedFunc).Pointer()
+	memoizedNameMap[p] = helpers.GetFunctionName(originalFunc)
+	memoizedNameMapLock.Unlock()
+}
+
 /*
-WithCache ensures the [HydrateFunc] results are saved in the [connection.ConnectionCache].
+Memoize ensures the [HydrateFunc] results are saved in the [connection.ConnectionCache].
 
 Use it to reduce the number of API calls if the HydrateFunc is used by multiple tables.
 
@@ -68,7 +90,7 @@ func (hydrate HydrateFunc) Memoize(opts ...MemoizeOption) HydrateFunc {
 	buildCacheKey := config.GetCacheKeyFunc
 	ttl := config.Ttl
 
-	return func(ctx context.Context, d *QueryData, h *HydrateData) (interface{}, error) {
+	memoizedFunc := func(ctx context.Context, d *QueryData, h *HydrateData) (interface{}, error) {
 		// build key
 		k, err := buildCacheKey(ctx, d, h)
 		if err != nil {
@@ -128,6 +150,11 @@ func (hydrate HydrateFunc) Memoize(opts ...MemoizeOption) HydrateFunc {
 		return callAndCacheHydrate(ctx, d, h, hydrate, cacheKey, ttl)
 
 	}
+
+	// store the memoized func in the name map
+	setMemoizedFuncName(memoizedFunc, hydrate)
+
+	return memoizedFunc
 }
 
 func (hydrate HydrateFunc) waitForHydrate(ctx context.Context, d *QueryData, h *HydrateData, functionLock *sync.WaitGroup, cacheKey string, ttl time.Duration) (interface{}, error) {

--- a/plugin/list_config.go
+++ b/plugin/list_config.go
@@ -50,7 +50,9 @@ type ListConfig struct {
 	ParentTags map[string]string
 
 	// Deprecated: Use IgnoreConfig
-	ShouldIgnoreError ErrorPredicate
+	ShouldIgnoreError      ErrorPredicate
+	namedHydrateFunc       *namedHydrateFunc
+	namedParentHydrateFunc *namedHydrateFunc
 }
 
 func (c *ListConfig) initialise(table *Table) {
@@ -81,6 +83,14 @@ func (c *ListConfig) initialise(table *Table) {
 	// default ignore and retry configs to table defaults
 	c.RetryConfig.DefaultTo(table.DefaultRetryConfig)
 	c.IgnoreConfig.DefaultTo(table.DefaultIgnoreConfig)
+
+	// populate the namedHydrateFunc hydrate func
+	n := newNamedHydrateFunc(c.Hydrate)
+	c.namedHydrateFunc = &n
+	if c.ParentHydrate != nil {
+		p := newNamedHydrateFunc(c.ParentHydrate)
+		c.namedParentHydrateFunc = &p
+	}
 
 	log.Printf("[TRACE] ListConfig.initialise complete: RetryConfig: %s, IgnoreConfig %s", c.RetryConfig.String(), c.IgnoreConfig.String())
 }

--- a/plugin/named_hydrate_func.go
+++ b/plugin/named_hydrate_func.go
@@ -1,0 +1,32 @@
+package plugin
+
+import (
+	"github.com/turbot/go-kit/helpers"
+	"log"
+)
+
+type namedHydrateFunc struct {
+	Func HydrateFunc
+	Name string
+}
+
+func newNamedHydrateFunc(f HydrateFunc) namedHydrateFunc {
+	res := namedHydrateFunc{Func: f}
+
+	originalName, isMemoized := getMemoizedFuncName(f)
+	if isMemoized {
+		log.Printf("[TRACE] newNamedHydrateFunc  - function %s is memoized", originalName)
+		res.Name = originalName
+	} else {
+		res.Name = helpers.GetFunctionName(f)
+		log.Printf("[TRACE] newNamedHydrateFunc  - function %s is NOT memoized", res.Name)
+	}
+	return res
+}
+
+func (h namedHydrateFunc) clone() namedHydrateFunc {
+	return namedHydrateFunc{
+		Func: h.Func,
+		Name: h.Name,
+	}
+}

--- a/plugin/named_hydrate_func.go
+++ b/plugin/named_hydrate_func.go
@@ -1,26 +1,16 @@
 package plugin
 
-import (
-	"github.com/turbot/go-kit/helpers"
-	"log"
-)
-
 type namedHydrateFunc struct {
 	Func HydrateFunc
 	Name string
 }
 
 func newNamedHydrateFunc(f HydrateFunc) namedHydrateFunc {
-	res := namedHydrateFunc{Func: f}
-
-	originalName, isMemoized := getMemoizedFuncName(f)
-	if isMemoized {
-		log.Printf("[TRACE] newNamedHydrateFunc  - function %s is memoized", originalName)
-		res.Name = originalName
-	} else {
-		res.Name = helpers.GetFunctionName(f)
-		log.Printf("[TRACE] newNamedHydrateFunc  - function %s is NOT memoized", res.Name)
+	res := namedHydrateFunc{
+		Func: f,
+		Name: getOriginalFuncName(f),
 	}
+
 	return res
 }
 

--- a/plugin/query_data.go
+++ b/plugin/query_data.go
@@ -150,8 +150,8 @@ type QueryData struct {
 
 	fetchMetadata         *hydrateMetadata
 	parentHydrateMetadata *hydrateMetadata
-	listHydrate           HydrateFunc
-	childHydrate          HydrateFunc
+	listHydrate           *namedHydrateFunc
+	childHydrate          *namedHydrateFunc
 }
 
 func newQueryData(connectionCallId string, p *Plugin, queryContext *QueryContext, table *Table, connectionData *ConnectionData, executeData *proto.ExecuteConnectionData, outputChan chan *proto.ExecuteResponse) (*QueryData, error) {
@@ -907,7 +907,7 @@ func (d *QueryData) removeReservedColumns(row *proto.Row) {
 	}
 }
 
-func (d *QueryData) setListCalls(listCall, childHydrate HydrateFunc) {
+func (d *QueryData) setListCalls(listCall, childHydrate *namedHydrateFunc) {
 	d.listHydrate = listCall
 	d.childHydrate = childHydrate
 }

--- a/plugin/required_hydrate_calls.go
+++ b/plugin/required_hydrate_calls.go
@@ -30,7 +30,7 @@ func (c requiredHydrateCallBuilder) Add(hydrateFunc HydrateFunc, callId string) 
 		}
 
 		// get the config for this hydrate function
-		config := c.queryData.Table.hydrateConfigMap[hydrateName]
+		config := getHydrateConfig(c, hydrateName)
 
 		call, err := newHydrateCall(config, c.queryData)
 		if err != nil {
@@ -48,6 +48,16 @@ func (c requiredHydrateCallBuilder) Add(hydrateFunc HydrateFunc, callId string) 
 		}
 	}
 	return nil
+}
+
+func getHydrateConfig(c requiredHydrateCallBuilder, hydrateName string) *HydrateConfig {
+	// first try plugin
+	config := c.queryData.plugin.hydrateConfigMap[hydrateName]
+	// fall back on table - we know there will at least be implicit config
+	if config == nil {
+		config = c.queryData.Table.hydrateConfigMap[hydrateName]
+	}
+	return config
 }
 
 func (c requiredHydrateCallBuilder) Get() []*hydrateCall {

--- a/plugin/serve.go
+++ b/plugin/serve.go
@@ -65,6 +65,7 @@ func Serve(opts *ServeOpts) {
 	// create the logger
 	logger := setupLogger()
 
+	log.Printf("[INFO] Serve")
 	// add logger into the context for the plugin create func
 	ctx := context.WithValue(context.Background(), context_key.Logger, logger)
 

--- a/plugin/table.go
+++ b/plugin/table.go
@@ -197,9 +197,13 @@ func (t *Table) buildHydrateConfigMap() {
 		if c.Hydrate == nil {
 			continue
 		}
-		hydrateName := helpers.GetFunctionName(c.Hydrate)
+		// to get name, create a namedFunc - this will take care of mapping memoized function named
+		hydrateName := newNamedHydrateFunc(c.Hydrate).Name
+
 		if _, ok := t.hydrateConfigMap[hydrateName]; !ok {
-			t.hydrateConfigMap[hydrateName] = &HydrateConfig{Func: c.Hydrate}
+			t.hydrateConfigMap[hydrateName] = &HydrateConfig{
+				Func: c.Hydrate,
+			}
 		}
 	}
 }

--- a/plugin/table_test.go
+++ b/plugin/table_test.go
@@ -219,7 +219,9 @@ var testCasesRequiredHydrateCalls = map[string]requiredHydrateCallsTest{
 		},
 		columns:   []string{"c1"},
 		fetchType: fetchTypeList,
-		expected:  []*hydrateCall{{Func: hydrate1, Name: "hydrate1"}},
+		expected: []*hydrateCall{
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate1, Name: "hydrate1"}},
+		},
 	},
 	"list - 1 hydrate, depends [HydrateDependencies]": {
 		table: &Table{
@@ -235,7 +237,10 @@ var testCasesRequiredHydrateCalls = map[string]requiredHydrateCallsTest{
 		},
 		columns:   []string{"c1"},
 		fetchType: fetchTypeList,
-		expected:  []*hydrateCall{{Func: hydrate1, Name: "hydrate1", Depends: []string{"hydrate2"}}, {Func: hydrate2, Name: "hydrate2"}},
+		expected: []*hydrateCall{
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate1, Name: "hydrate1"}, Depends: []string{"hydrate2"}},
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate2, Name: "hydrate2"}},
+		},
 	},
 	"get - 2 hydrate, depends [HydrateDependencies]": {
 		table: &Table{
@@ -252,7 +257,10 @@ var testCasesRequiredHydrateCalls = map[string]requiredHydrateCallsTest{
 		},
 		columns:   []string{"c1", "c2"},
 		fetchType: fetchTypeGet,
-		expected:  []*hydrateCall{{Func: hydrate1, Name: "hydrate1", Depends: []string{"hydrate3"}}, {Func: hydrate3, Name: "hydrate3"}, {Func: hydrate2, Name: "hydrate2"}},
+		expected: []*hydrateCall{
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate1, Name: "hydrate1"}, Depends: []string{"hydrate3"}},
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate3, Name: "hydrate3"}},
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate2, Name: "hydrate2"}}},
 	},
 	"get - 2 depends [HydrateDependencies]": {
 		table: &Table{
@@ -272,7 +280,10 @@ var testCasesRequiredHydrateCalls = map[string]requiredHydrateCallsTest{
 		},
 		columns:   []string{"c1"},
 		fetchType: fetchTypeGet,
-		expected:  []*hydrateCall{{Func: hydrate1, Name: "hydrate1", Depends: []string{"hydrate2"}}, {Func: hydrate2, Name: "hydrate2", Depends: []string{"hydrate3"}}, {Func: hydrate3, Name: "hydrate3"}},
+		expected: []*hydrateCall{
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate1, Name: "hydrate1"}, Depends: []string{"hydrate2"}},
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate2, Name: "hydrate2"}, Depends: []string{"hydrate3"}},
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate3, Name: "hydrate3"}}},
 	},
 	"get - unreferenced depends [HydrateDependencies]": {
 		table: &Table{
@@ -292,7 +303,8 @@ var testCasesRequiredHydrateCalls = map[string]requiredHydrateCallsTest{
 		},
 		columns:   []string{"c3"},
 		fetchType: fetchTypeGet,
-		expected:  []*hydrateCall{{Func: hydrate3, Name: "hydrate3"}},
+		expected: []*hydrateCall{
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate3, Name: "hydrate3"}}},
 	},
 
 	"list - 1 hydrate, depends": {
@@ -309,7 +321,9 @@ var testCasesRequiredHydrateCalls = map[string]requiredHydrateCallsTest{
 		},
 		columns:   []string{"c1"},
 		fetchType: fetchTypeList,
-		expected:  []*hydrateCall{{Func: hydrate1, Name: "hydrate1", Depends: []string{"hydrate2"}}, {Func: hydrate2, Name: "hydrate2"}},
+		expected: []*hydrateCall{
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate1, Name: "hydrate1"}, Depends: []string{"hydrate2"}},
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate2, Name: "hydrate2"}}},
 	},
 	"get - 2 hydrate, depends": {
 		table: &Table{
@@ -326,7 +340,11 @@ var testCasesRequiredHydrateCalls = map[string]requiredHydrateCallsTest{
 		},
 		columns:   []string{"c1", "c2"},
 		fetchType: fetchTypeGet,
-		expected:  []*hydrateCall{{Func: hydrate1, Name: "hydrate1", Depends: []string{"hydrate3"}}, {Func: hydrate3, Name: "hydrate3"}, {Func: hydrate2, Name: "hydrate2"}},
+		expected: []*hydrateCall{
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate1, Name: "hydrate1"}, Depends: []string{"hydrate3"}},
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate3, Name: "hydrate3"}},
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate2, Name: "hydrate2"}},
+		},
 	},
 	"get - 2 depends": {
 		table: &Table{
@@ -346,7 +364,11 @@ var testCasesRequiredHydrateCalls = map[string]requiredHydrateCallsTest{
 		},
 		columns:   []string{"c1"},
 		fetchType: fetchTypeGet,
-		expected:  []*hydrateCall{{Func: hydrate1, Name: "hydrate1", Depends: []string{"hydrate2"}}, {Func: hydrate2, Name: "hydrate2", Depends: []string{"hydrate3"}}, {Func: hydrate3, Name: "hydrate3"}},
+		expected: []*hydrateCall{
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate1, Name: "hydrate1"}, Depends: []string{"hydrate2"}},
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate2, Name: "hydrate2"}, Depends: []string{"hydrate3"}},
+			{namedHydrateFunc: namedHydrateFunc{Func: hydrate3, Name: "hydrate3"}},
+		},
 	},
 	"get - unreferenced depends": {
 		table: &Table{
@@ -366,7 +388,7 @@ var testCasesRequiredHydrateCalls = map[string]requiredHydrateCallsTest{
 		},
 		columns:   []string{"c3"},
 		fetchType: fetchTypeGet,
-		expected:  []*hydrateCall{{Func: hydrate3, Name: "hydrate3"}},
+		expected:  []*hydrateCall{{namedHydrateFunc: namedHydrateFunc{Func: hydrate3, Name: "hydrate3"}}},
 	},
 }
 

--- a/plugin/table_validate.go
+++ b/plugin/table_validate.go
@@ -121,6 +121,16 @@ func (t *Table) validateHydrateDependencies() []string {
 	return validationErrors
 }
 
+// ensure that no hydrate config is declared for a hydrate func which has global hydrate config
+func (t *Table) validateHydrateConfig() {
+	var validationErrors []string
+	for funcName := range t.hydrateConfigMap {
+		if _, globalConfigExists := t.Plugin.hydrateConfigMap[funcName]; globalConfigExists {
+			validationErrors = append(validationErrors, fmt.Sprintf("table '%s' declares HydrateConfig for '%s' which also has global HydrateConfig declared by the plugin", t.Name, funcName))
+		}
+	}
+}
+
 func (t *Table) detectCyclicHydrateDependencies() string {
 	var dependencyGraph = topsort.NewGraph()
 	dependencyGraph.AddNode("root")


### PR DESCRIPTION
Add memoizedNameMap and use to retrieve underlying names of memoized functions Add hydrate config to plugin