### PR TITLE
 fix list func names for parent/child hydrate functions not being populated in _ctx field. Closes #670

### DIFF
--- a/plugin/hydrate_error.go
+++ b/plugin/hydrate_error.go
@@ -14,7 +14,11 @@ import (
 )
 
 // RetryHydrate function invokes the hydrate function with retryable errors and retries the function until the maximum attempts before throwing error
-func RetryHydrate(ctx context.Context, d *QueryData, hydrateData *HydrateData, hydrate namedHydrateFunc, retryConfig *RetryConfig) (hydrateResult interface{}, err error) {
+func RetryHydrate(ctx context.Context, d *QueryData, hydrateData *HydrateData, hydrate HydrateFunc, retryConfig *RetryConfig) (hydrateResult interface{}, err error) {
+	return retryNamedHydrate(ctx, d, hydrateData, newNamedHydrateFunc(hydrate), retryConfig)
+}
+
+func retryNamedHydrate(ctx context.Context, d *QueryData, hydrateData *HydrateData, hydrate namedHydrateFunc, retryConfig *RetryConfig) (hydrateResult interface{}, err error) {
 	ctx, span := telemetry.StartSpan(ctx, d.Table.Plugin.Name, "RetryHydrate (%s)", d.Table.Name)
 	span.SetAttributes(
 		attribute.String("hydrate-func", hydrate.Name),

--- a/plugin/plugin_connection_config.go
+++ b/plugin/plugin_connection_config.go
@@ -57,7 +57,7 @@ func (p *Plugin) updateConnections(ctx context.Context, changed []*proto.Connect
 // add connections for all the provided configs
 // NOTE: this (may) mutate failedConnections, exemplarSchema and exemplarTableMap
 func (p *Plugin) addConnections(configs []*proto.ConnectionConfig, updateData *connectionUpdateData) {
-	log.Printf("[TRACE] SetAllConnectionConfigs setting %d configs", len(configs))
+	log.Printf("[INFO] Plugin.addConnections adding %d configs", len(configs))
 
 	for _, config := range configs {
 		if config.IsAggregator() {
@@ -211,7 +211,7 @@ func (p *Plugin) logChanges(added []*proto.ConnectionConfig, deleted []*proto.Co
 	for i, c := range changed {
 		changedNames[i] = c.Connection
 	}
-	log.Printf("[TRACE] UpdateConnectionConfigs added: %s, deleted: %s, changed: %s", strings.Join(addedNames, ","), strings.Join(deletedNames, ","), strings.Join(changedNames, ","))
+	log.Printf("[INFO] UpdateConnectionConfigs added: %s, deleted: %s, changed: %s", strings.Join(addedNames, ","), strings.Join(deletedNames, ","), strings.Join(changedNames, ","))
 }
 
 // this is the default ConnectionConfigChanged callback function

--- a/plugin/query_data.go
+++ b/plugin/query_data.go
@@ -254,6 +254,8 @@ func (d *QueryData) shallowCopy() *QueryData {
 		listHydrate:            d.listHydrate,
 		childHydrate:           d.childHydrate,
 		rateLimiterScopeValues: make(map[string]string),
+		fetchMetadata:          d.fetchMetadata,
+		parentHydrateMetadata:  d.parentHydrateMetadata,
 	}
 
 	// NOTE: we create a deep copy of the keyColumnQuals

--- a/plugin/query_data_rate_limiters.go
+++ b/plugin/query_data_rate_limiters.go
@@ -139,7 +139,7 @@ func (d *QueryData) resolveListRateLimiters() error {
 	return nil
 }
 
-func (d *QueryData) setListLimiterMetadata(fetchDelay time.Duration) {
+func (d *QueryData) setListMetadata(fetchDelay time.Duration) {
 	fetchMetadata := &hydrateMetadata{
 		FuncName:     d.listHydrate.Name,
 		RateLimiters: d.fetchLimiters.rateLimiter.LimiterNames(),

--- a/plugin/row_data.go
+++ b/plugin/row_data.go
@@ -216,7 +216,7 @@ func (r *rowData) callHydrateWithRetries(ctx context.Context, d *QueryData, hydr
 		if shouldRetryError(ctx, d, h, err, retryConfig) {
 			log.Printf("[TRACE] retrying hydrate")
 			hydrateData := &HydrateData{Item: r.item, ParentItem: r.parentItem, HydrateResults: r.hydrateResults}
-			hydrateResult, err = RetryHydrate(ctx, d, hydrateData, hydrate, retryConfig)
+			hydrateResult, err = retryNamedHydrate(ctx, d, hydrateData, hydrate, retryConfig)
 			log.Printf("[TRACE] back from retry")
 		}
 	}

--- a/plugin/table_fetch.go
+++ b/plugin/table_fetch.go
@@ -382,7 +382,7 @@ func (t *Table) executeListCall(ctx context.Context, queryData *QueryData) {
 		childHydrate = t.List.namedHydrate
 	}
 
-	// store the list call and child hydrate call - these will be used later when we call setListLimiterMetadata
+	// store the list call and child hydrate call - these will be used later when we call setListMetadata
 	queryData.setListCalls(listCall, childHydrate)
 
 	// NOTE: if there is an IN qual, the qual value will be a list of values
@@ -494,7 +494,7 @@ func (t *Table) doList(ctx context.Context, queryData *QueryData, listCall named
 	// now wait for any configured 'list' rate limiters
 	fetchDelay := queryData.fetchLimiters.wait(ctx)
 	// set the metadata
-	queryData.setListLimiterMetadata(fetchDelay)
+	queryData.setListMetadata(fetchDelay)
 
 	log.Printf("[TRACE] doList: no matrix item")
 
@@ -545,7 +545,7 @@ func (t *Table) listForEachMatrixItem(ctx context.Context, queryData *QueryData,
 			// now wait for any configured 'list' rate limiters
 			fetchDelay := matrixQueryData.fetchLimiters.wait(ctx)
 			// set the metadata
-			matrixQueryData.setListLimiterMetadata(fetchDelay)
+			matrixQueryData.setListMetadata(fetchDelay)
 
 			// we cannot retry errors in the list hydrate function after streaming has started
 			listRetryConfig := t.List.RetryConfig.GetListRetryConfig()


### PR DESCRIPTION
revert signature of RetryHydrate