### PR TITLE
Add connection name to the error message while streaming errors. Closes #684

### DIFF
--- a/plugin/query_data.go
+++ b/plugin/query_data.go
@@ -19,6 +19,7 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/quals"
 	"github.com/turbot/steampipe-plugin-sdk/v5/query_cache"
 	"github.com/turbot/steampipe-plugin-sdk/v5/rate_limiter"
+	"github.com/turbot/steampipe-plugin-sdk/v5/sperr"
 	"github.com/turbot/steampipe-plugin-sdk/v5/telemetry"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/semaphore"
@@ -828,7 +829,7 @@ func (d *QueryData) streamRow(row *proto.Row) {
 
 func (d *QueryData) streamError(err error) {
 	log.Printf("[WARN] QueryData StreamError %v (%s)", err, d.connectionCallId)
-	d.errorChan <- err
+	d.errorChan <- sperr.WrapWithMessage(err, d.Connection.Name)
 }
 
 // TODO KAI this seems to get called even after cancellation


### PR DESCRIPTION
```
> 
> select * from aws_all.aws_account;

Error: test_aab_2: operation error STS: GetCallerIdentity, https response error StatusCode: 403, RequestID: 1aa53dee-c516-4197-9b10-b3fcd594xxxx, api error SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
        test_aab: operation error STS: GetCallerIdentity, https response error StatusCode: 403, RequestID: 04e432dd-f6b4-45e1-b940-3b50e76cxxxx, api error SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details. (SQLSTATE HV000)

+-----------------+------------------------+-----------------+---------------------------------------------------------------+--------------------------+----------------------->
| account_aliases | arn                    | organization_id | organization_arn                                              | organization_feature_set | organization_master_ac>
+-----------------+------------------------+-----------------+---------------------------------------------------------------+--------------------------+----------------------->
| ["redhood-aaa"] | arn:aws:::4533195xxxxx | o-c3a5y4xxxxx    | arn:aws:organizations::67694419xxxx:organization/o-c3a5y4xxxx | ALL                      | arn:aws:organizations:>
+-----------------+------------------------+-----------------+---------------------------------------------------------------+--------------------------+----------------------->
> 
```