### PR TITLE
fix: show panic stack trace in error logs

### DIFF
--- a/plugin/hydrate_error.go
+++ b/plugin/hydrate_error.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"runtime/debug"
 	"time"
 
 	"github.com/sethvargo/go-retry"
@@ -127,7 +128,7 @@ func WrapHydrate(hydrate namedHydrateFunc, ignoreConfig *IgnoreConfig) namedHydr
 
 		defer func() {
 			if r := recover(); r != nil {
-				log.Printf("[WARN] recovered a panic from a wrapped hydrate function: %v\n", r)
+				log.Printf("[WARN] recovered a panic from a wrapped hydrate function: %v\n%s", r, debug.Stack())
 				err = status.Error(codes.Internal, fmt.Sprintf("hydrate function %s failed with panic %v", hydrate.Name, r))
 			}
 		}()


### PR DESCRIPTION
This PR shows stack trace in plugin error log file when panics occur, e.g.:

```
2025-05-15 17:33:57.727 UTC [WARN]  steampipe-plugin-myapp.plugin: [WARN]  174733043711: recovered a panic from a wrapped hydrate function: runtime error: invalid memory address or nil pointer dereference
goroutine 161 [running]:
runtime/debug.Stack()
        /home/patrick/.local/share/mise/installs/go/1.24.3/src/runtime/debug/stack.go:26 +0x5e
github.com/turbot/steampipe-plugin-sdk/v5/plugin.(*rowData).callHydrateWithRetries.WrapHydrate.func2.2()
        /home/patrick/go/src/github.com/turbot/steampipe-plugin-sdk/plugin/hydrate_error.go:131 +0x58
panic({0x1ae5120?, 0x35a1bf0?})
        /home/patrick/.local/share/mise/installs/go/1.24.3/src/runtime/panic.go:792 +0x132
myhost/mygroup/steampipe-plugin-myapp/myapp.(*transport).RoundTrip(0xc015e2e780, 0xc0001f5900)
        /home/patrick/workspaces/steampipe-plugin-myapp/myapp/transport.go:42 +0x26d
net/http.send(0xc0001f5900, {0x21a9ec0, 0xc015e2e780}, {0x479101?, 0x90?, 0x0?})
        /home/patrick/.local/share/mise/installs/go/1.24.3/src/net/http/client.go:259 +0x5e2
net/http.(*Client).send(0xc015e1ede0, 0xc0001f5900, {0x784ed48ed5c0?, 0x1500000000000030?, 0x0?})
        /home/patrick/.local/share/mise/installs/go/1.24.3/src/net/http/client.go:180 +0x91
net/http.(*Client).do(0xc015e1ede0, 0xc0001f5900)
        /home/patrick/.local/share/mise/installs/go/1.24.3/src/net/http/client.go:728 +0x989
net/http.(*Client).Do(0x21bf818?, 0x21bf818?)
        /home/patrick/.local/share/mise/installs/go/1.24.3/src/net/http/client.go:587 +0x13
myhost/mygroup/steampipe-plugin-myapp/myapp/api.(*Client).sendGetAssetV1Inventory(0xc015e2dd60, {0x21bf818, 0xc0006340f0}, {{{0x0, 0x0}, 0x0}, {0x0, 0x0}, {{0x0, 0x0}, ...}, ...})
        /home/patrick/workspaces/steampipe-plugin-myapp/myapp/api/oas_client_gen.go:1018 +0x1344
myhost/mygroup/steampipe-plugin-myapp/myapp/api.(*Client).GetAssetV1Inventory(...)
        /home/patrick/workspaces/steampipe-plugin-myapp/myapp/api/oas_client_gen.go:819
myhost/mygroup/steampipe-plugin-myapp/myapp.inventoryListAPICall({0x21bf818?, 0xc015e1ed80?}, 0xc014b25758?, {0x1b9c480?, 0xc000822c80?})
        /home/patrick/workspaces/steampipe-plugin-myapp/myapp/table_inventory.go:116 +0xa7
myhost/mygroup/steampipe-plugin-myapp/myapp.tableInventory.createInventoryListHydrate.GenericListHydrate[...].func3(0xc0007b6c00, 0x19c5a01)
        /home/patrick/workspaces/steampipe-plugin-myapp/myapp/utils.go:261 +0xbac
github.com/turbot/steampipe-plugin-sdk/v5/plugin.(*rowData).callHydrateWithRetries.WrapHydrate.func2({0x21bf818, 0xc015e1ed20}, 0xc0007b6c00, 0xc015e1ed50)
        /home/patrick/go/src/github.com/turbot/steampipe-plugin-sdk/plugin/hydrate_error.go:136 +0x30b
github.com/turbot/steampipe-plugin-sdk/v5/plugin.(*rowData).callHydrateWithRetries(0xc014b25cd0, {0x21bf818, 0xc015dbafc0}, 0xc0007b6c00, {0xc000808140?, {0xc000050e08?, 0xc014b25df0?}}, 0xc0007a30c0, 0xc014b25c80)
        /home/patrick/go/src/github.com/turbot/steampipe-plugin-sdk/plugin/row_data.go:219 +0x3f2
github.com/turbot/steampipe-plugin-sdk/v5/plugin.(*Table).doList(0xc0005c6340, {0x21bf818, 0xc0151901b0}, 0xc0007b6c00, {0xc000808140?, {0xc000050e08?, 0xc014ae4f78?}})
        /home/patrick/go/src/github.com/turbot/steampipe-plugin-sdk/plugin/table_fetch.go:506 +0x4ca
github.com/turbot/steampipe-plugin-sdk/v5/plugin.(*Table).executeListCall(0xc0005c6340, {0x21bf818, 0xc0151900f0}, 0xc0007b6c00)
        /home/patrick/go/src/github.com/turbot/steampipe-plugin-sdk/plugin/table_fetch.go:399 +0x528
created by github.com/turbot/steampipe-plugin-sdk/v5/plugin.(*Table).fetchItems in goroutine 156
        /home/patrick/go/src/github.com/turbot/steampipe-plugin-sdk/plugin/table_fetch.go:48 +0x24e

```

This greatly eases troubleshooting.