### PR TITLE
fix: ensure plugin errors affect exit code in steampipe-export

### DIFF
--- a/anywhere/local_plugin_stream.go
+++ b/anywhere/local_plugin_stream.go
@@ -16,6 +16,8 @@ type LocalPluginStream struct {
 	// this channel is closed whenever the local plugin stream receives its first row or error
 	// this is to make sure either it waits for the first row or error before returning from Recv
 	ready chan struct{}
+	// closed when the stream is done
+	done chan struct{}
 }
 
 func NewLocalPluginStream(ctx context.Context) *LocalPluginStream {
@@ -23,54 +25,110 @@ func NewLocalPluginStream(ctx context.Context) *LocalPluginStream {
 		ctx:   ctx,
 		rows:  make(chan *proto.ExecuteResponse, localPluginStreamBuffer),
 		ready: make(chan struct{}, 1),
+		done:  make(chan struct{}),
 	}
 }
+
 func (s *LocalPluginStream) Send(r *proto.ExecuteResponse) error {
-	// make the ready channel
-	defer func() {
+	select {
+	case <-s.done:
+		return nil
+	default:
+		// make the ready channel
 		select {
 		case <-s.ready:
-			//do nothing
+			// already closed
 		default:
 			close(s.ready)
 		}
-	}()
-	s.rows <- r
-	return nil
+		select {
+		case s.rows <- r:
+			return nil
+		case <-s.done:
+			return nil
+		case <-s.ctx.Done():
+			return s.ctx.Err()
+		}
+	}
 }
 
 func (s *LocalPluginStream) Error(err error) {
-	// make the ready channel
-	defer func() {
+	select {
+	case <-s.done:
+		return
+	default:
+		s.err = err
+		// Ensure ready channel is closed
 		select {
 		case <-s.ready:
-			//do nothing
+			// already closed
 		default:
 			close(s.ready)
 		}
-	}()
-	s.err = err
+		close(s.done)
+	}
 }
 
 func (s *LocalPluginStream) Recv() (*proto.ExecuteResponse, error) {
-	// wait for the first row or error
-	<-s.ready
-
-	// if an error has been sent, return it
+	// Check for error first
 	if err := s.err; err != nil {
 		s.err = nil
-		// reset the ready channel so that the next call to Recv will wait for the next row or error
-		s.ready = make(chan struct{}, 1)
 		return nil, err
 	}
-	resp := <-s.rows
-	// reset the ready channel so that the next call to Recv will wait for the next row or error
-	if resp == nil {
-		s.ready = make(chan struct{}, 1)
+
+	// Check if done
+	select {
+	case <-s.done:
+		return nil, nil
+	case <-s.ctx.Done():
+		return nil, s.ctx.Err()
+	default:
 	}
-	return resp, nil
+
+	// Wait for ready or context cancellation
+	select {
+	case <-s.ready:
+		// ready channel closed, proceed
+	case <-s.ctx.Done():
+		return nil, s.ctx.Err()
+	case <-s.done:
+		return nil, nil
+	}
+
+	// Check for error again after ready
+	if err := s.err; err != nil {
+		s.err = nil
+		return nil, err
+	}
+
+	// Try to get a row
+	select {
+	case <-s.done:
+		return nil, nil
+	case <-s.ctx.Done():
+		return nil, s.ctx.Err()
+	case resp, ok := <-s.rows:
+		if !ok {
+			// Channel is closed, we're done
+			close(s.done)
+			return nil, nil
+		}
+		// Don't create a new ready channel - this was causing the issue
+		// The ready channel should only be used for the first row
+		return resp, nil
+	}
 }
 
 func (s *LocalPluginStream) Context() context.Context {
 	return s.ctx
+}
+
+// Ready returns a channel that is closed when the stream is ready to receive data
+func (s *LocalPluginStream) Ready() <-chan struct{} {
+	return s.ready
+}
+
+// Rows returns the rows channel for direct access
+func (s *LocalPluginStream) Rows() chan *proto.ExecuteResponse {
+	return s.rows
 }

--- a/grpc/pluginServer.go
+++ b/grpc/pluginServer.go
@@ -132,7 +132,10 @@ func (s PluginServer) CallExecuteAsync(req *proto.ExecuteRequest, stream *anywhe
 		err := s.executeFunc(req, stream)
 		if err != nil {
 			stream.Error(err)
+			return
 		}
+		// Signal completion by sending nil
+		stream.Send(nil)
 	}()
 }
 


### PR DESCRIPTION
When a plugin encounters an error during streaming, the error is now properly propagated to affect the exit code. Previously, errors from the plugin server were being logged but not affecting the program's exit status.