### PR TITLE
fix: cache key should only consider actually requested columns

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"github.com/danwakefield/fnmatch"
 	"log"
 	"os"
 	"path"
@@ -13,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/danwakefield/fnmatch"
 	"github.com/fsnotify/fsnotify"
 	"github.com/gertd/go-pluralize"
 	"github.com/hashicorp/go-hclog"
@@ -450,7 +450,7 @@ func (p *Plugin) executeForConnection(streamContext context.Context, req *proto.
 	cacheRequest := &query_cache.CacheRequest{
 		Table:          table.Name,
 		QualMap:        cacheQualMap,
-		Columns:        queryData.getColumnNames(), // all column names returned by the required hydrate functions
+		Columns:        queryContext.Columns,
 		Limit:          limit,
 		ConnectionName: connectionName,
 		TtlSeconds:     queryContext.CacheTTL,

--- a/query_cache/index_item.go
+++ b/query_cache/index_item.go
@@ -51,7 +51,7 @@ func (i IndexItem) satisfiedByRequest(req *CacheRequest, keyColumns map[string]*
 }
 
 // satisfiesColumns returns whether this index item satisfies the given columns
-// used when determining whether this IndexItem satisfies a cache reques
+// used when determining whether this IndexItem satisfies a cache request
 func (i IndexItem) satisfiesColumns(columns []string) bool {
 	for _, c := range columns {
 		if !slices.Contains(i.Columns, c) {
@@ -63,7 +63,7 @@ func (i IndexItem) satisfiesColumns(columns []string) bool {
 }
 
 // satisfiesLimit returns whether this index item satisfies the given limit
-// used when determining whether this IndexItem satisfies a cache reques
+// used when determining whether this IndexItem satisfies a cache request
 func (i IndexItem) satisfiesLimit(limit int64) bool {
 	// if index item has is no limit, it will be -1
 	if i.Limit == -1 {


### PR DESCRIPTION
This PR resolves an issue when querying a table with Steampipe for a subset of columns, then re-querying the same table with additional columns, the latter are not populated and returned as `<null>`:

```
> select
  id
from
  synapps_asset_inventory
where
  type = 'CLOUD'
  and subtype = 'AWS'
limit 2
+------------+
| id         |
+------------+
| INV-123456 |
| INV-234567 |
+------------+
> select
  id, name
from
  synapps_asset_inventory
where
  type = 'CLOUD'
  and subtype = 'AWS'
limit 2
+------------+--------+
| id         | name   |
+------------+--------+
| INV-123456 | <null> |
| INV-234567 | <null> |
+------------+--------+
```
Clearing the cache resolves the issue:
```
> .cache clear
> select
  id, name
from
  synapps_asset_inventory
where
  type = 'CLOUD'
  and subtype = 'AWS'
limit 2
+------------+-------------+
| id         | name        |
+------------+-------------+
| INV-123456 | myaccount-1 |
| INV-234567 | myaccount-2 |
+------------+-------------+
```

This happens because our plugin only requests the fields from API that are actually present in the SQL query.