### PR TITLE
fix: always include filtered matrix item in cache key

### DIFF
--- a/plugin/get_config.go
+++ b/plugin/get_config.go
@@ -67,9 +67,9 @@ type GetConfig struct {
 	Hydrate HydrateFunc
 	// key or keys which are used to uniquely identify rows - used to determine whether  a query is a 'get' call
 	KeyColumns KeyColumnSlice
-	// a function which will return whenther to ignore a given error
+	// a function which will return whether to ignore a given error
 	IgnoreConfig *IgnoreConfig
-	// a function which will return whenther to retry the call if an error is returned
+	// a function which will return whether to retry the call if an error is returned
 	RetryConfig *RetryConfig
 	Tags        map[string]string
 

--- a/plugin/list_config.go
+++ b/plugin/list_config.go
@@ -2,9 +2,10 @@ package plugin
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/gertd/go-pluralize"
 	"github.com/turbot/steampipe-plugin-sdk/v5/rate_limiter"
-	"log"
 )
 
 /*
@@ -41,9 +42,9 @@ type ListConfig struct {
 	KeyColumns KeyColumnSlice
 	// the parent list function - if we list items with a parent-child relationship, this will list the parent items
 	ParentHydrate HydrateFunc
-	// a function which will return whenther to ignore a given error
+	// a function which will return whether to ignore a given error
 	IgnoreConfig *IgnoreConfig
-	// a function which will return whenther to retry the call if an error is returned
+	// a function which will return whether to retry the call if an error is returned
 	RetryConfig *RetryConfig
 
 	Tags       map[string]string

--- a/plugin/query_data.go
+++ b/plugin/query_data.go
@@ -362,9 +362,7 @@ func (d *QueryData) filterMatrixItems() {
 				if matrixQuals.SingleEqualsQual() {
 					includeMatrixItem = d.shouldIncludeMatrixItem(matrixQuals, val)
 					// store this column - we will need this when building a cache key
-					if !includeMatrixItem {
-						d.filteredMatrixColumns = append(d.filteredMatrixColumns, col)
-					}
+					d.filteredMatrixColumns = append(d.filteredMatrixColumns, col)
 				}
 			} else {
 				log.Printf("[TRACE] quals found for matrix column: %s", col)
@@ -520,7 +518,7 @@ func (d *QueryData) setQuals(qualMap KeyColumnQualMap) {
 }
 
 func (d *QueryData) shouldIncludeMatrixItem(quals *KeyColumnQuals, matrixVal interface{}) bool {
-	log.Printf("[TRACE] there is a single equals qual")
+	log.Printf("[TRACE] shouldIncludeMatrixItem - there is a single equals qual")
 
 	// if the value is an array, this is an IN query - check whether the array contains the matrix value
 	if listValue := quals.Quals[0].Value.GetListValue(); listValue != nil {
@@ -913,13 +911,14 @@ func (d *QueryData) waitForRowsToComplete(rowWg *sync.WaitGroup, rowChan chan *p
 // this will include all key column quals, and also any quals which were used to filter the matrix items
 func (d *QueryData) getCacheQualMap() map[string]*proto.Quals {
 	res := d.Quals.ToProtoQualMap()
-	// now add in any additional (non-keycolumn) quals which were used to folter the matrix
+	// now add in any additional (non-keycolumn) quals which were used to filter the matrix
 	for _, col := range d.filteredMatrixColumns {
 		if _, ok := res[col]; !ok {
 			log.Printf("[TRACE] getCacheQualMap - adding non-key column qual %s as it was used to filter the matrix items", col)
 			res[col] = d.QueryContext.UnsafeQuals[col]
 		}
 	}
+	log.Printf("[TRACE] getCacheQualMap - res=%#q", res)
 	return res
 }
 


### PR DESCRIPTION
Without this PR, when using matrix items (that I'm adding to the OVH plugin in https://github.com/francois2metz/steampipe-plugin-ovh/pull/74), queries such as the following are missing items when removing the filtered matrix item column, and clearing the cache resolves the issue:

```
> select name, region from ovh_perso.ovh_cloud_storage_s3 where project_id = '2cf14530bc1e4ba5a3ae44fbd4cbe866' and region = 'GRA'
+---------------+--------+
| name          | region |
+---------------+--------+
| test-pdecat-1 | GRA    |
+---------------+--------+
1 row

> select name, region from ovh_perso.ovh_cloud_storage_s3 where project_id = '2cf14530bc1e4ba5a3ae44fbd4cbe866'
+---------------+--------+
| name          | region |
+---------------+--------+
| test-pdecat-1 | GRA    |
+---------------+--------+
1 row

> .cache clear
> select name, region from ovh_perso.ovh_cloud_storage_s3 where project_id = '2cf14530bc1e4ba5a3ae44fbd4cbe866'
+---------------+-------------+
| name          | region      |
+---------------+-------------+
| test-pdecat-1 | GRA         |
| test-pdecat-3 | EU-WEST-PAR |
+---------------+-------------+
2 rows
```