### PR TITLE
fix: pin chaos test steampipe checkout to latest release tag

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -47,10 +47,17 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: sdk
 
+      - name: Get latest Steampipe release tag
+        id: steampipe-release
+        run: |
+          tag=$(curl -s https://api.github.com/repos/turbot/steampipe/releases/latest | jq -r '.tag_name')
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+
       - name: Checkout Steampipe
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: turbot/steampipe
+          ref: ${{ steps.steampipe-release.outputs.tag }}
           path: steampipe
 
       - name: Update go.mod and build Steampipe


### PR DESCRIPTION
## Summary
- The chaos acceptance tests were failing because the Steampipe checkout used the `develop` branch, which has a broken OpenTelemetry transitive dependency (`go.opentelemetry.io/otel/sdk/metric` sub-packages removed in v1.40.0).
- Dynamically resolve and pin the Steampipe checkout to the latest release tag via the GitHub API, ensuring we always build against a stable version.

## Test plan
- [ ] Verify the chaos acceptance tests pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)