### PR TITLE
Upgrade Go to 1.26 and golangci-lint to v2

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -16,13 +16,13 @@ jobs:
         - name: Set up Go
           uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
           with:
-            go-version: 1.22
+            go-version: 1.26
 
         - name: golangci-lint
-          uses: golangci/golangci-lint-action@38e1018663fa5173f3968ea0777460d3de38f256 # v5.3.0
+          uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
           continue-on-error: true # we dont want to enforce just yet
           with:
-            version: v1.52.2
+            version: v2.10.1
             args: --timeout=15m --config=.golangci.yml
 
         - name: Run SDK Unit Tests
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.22
+          go-version: 1.26
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,42 +1,51 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    # default rules
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - typecheck
-    - unused
-    # other rules
     - asasalint
     - asciicheck
     - bidichk
     - durationcheck
-    - exportloopref
+    - errcheck
     - forbidigo
-    - gocritic
     - gocheckcompilerdirectives
+    - gocritic
     - gosec
+    - govet
+    - ineffassign
     - makezero
     - nilerr
     - nolintlint
     - reassign
     - sqlclosecheck
+    - staticcheck
     - unconvert
-
-linters-settings:
-  nolintlint:
-    require-explanation: true
-    require-specific: true
-
-  gocritic:
-    disabled-checks:
-      - ifElseChain       # style
-      - singleCaseSwitch  # style & it's actually not a bad idea to use single case switch in some cases
-      - assignOp          # style
-      - commentFormatting # style
-
-run:
-  timeout: 5m
+    - unused
+  settings:
+    gocritic:
+      disabled-checks:
+        - ifElseChain
+        - singleCaseSwitch
+        - assignOp
+        - commentFormatting
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbot/steampipe-plugin-sdk/v5
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect


### PR DESCRIPTION
## Summary
- Upgrade Go version from 1.24 to 1.26 in `go.mod` and CI workflows
- Migrate `.golangci.yml` to v2 format, removing deprecated linters (`exportloopref`, `gosimple`, `typecheck`)
- Update `golangci-lint-action` from v5.3.0 to v7.0.1 with golangci-lint v2.10.1 (required for Go 1.26 support)

## Test plan
- [ ] CI unit tests pass with Go 1.26
- [ ] golangci-lint runs successfully with v2 config
- [ ] Chaos acceptance tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)