### PR TITLE
perf: cache pluralize.Client at package level

### DIFF
--- a/plugin/connection_data.go
+++ b/plugin/connection_data.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/gertd/go-pluralize"
 	"github.com/turbot/go-kit/filewatcher"
 	"github.com/turbot/steampipe-plugin-sdk/v5/getter"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc"
@@ -178,7 +177,7 @@ func (d *ConnectionData) resolveAggregatorTableMap(aggregatorConfig *proto.Conne
 					connectionName,
 					tableName,
 					msgCount,
-					pluralize.NewClient().Pluralize("message", msgCount, false))
+					pluralizeClient().Pluralize("message", msgCount, false))
 
 				for _, m := range messages {
 					log.Println("[INFO]", m)
@@ -209,7 +208,7 @@ func (d *ConnectionData) setAggregatedTablesByConnection(aggregatorConfig *proto
 			log.Printf("[INFO] Child connection %s excluded %d %s",
 				c,
 				exclusionCount,
-				pluralize.NewClient().Pluralize("table", exclusionCount, false))
+				pluralizeClient().Pluralize("table", exclusionCount, false))
 
 			for t, reason := range exclusionReasons {
 				log.Printf("[INFO] - %s : %s", t, reason)

--- a/plugin/get_config.go
+++ b/plugin/get_config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/gertd/go-pluralize"
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/v5/rate_limiter"
 )
@@ -165,7 +164,7 @@ func (c *GetConfig) Validate(table *Table) []string {
 				table.Name,
 				getHydrateName,
 				numDeps,
-				pluralize.NewClient().Pluralize("dependency", numDeps, false)))
+				pluralizeClient().Pluralize("dependency", numDeps, false)))
 			break
 		}
 	}

--- a/plugin/key_column.go
+++ b/plugin/key_column.go
@@ -5,7 +5,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/gertd/go-pluralize"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/quals"
 	"github.com/turbot/steampipe-plugin-sdk/v5/query_cache"
@@ -113,7 +112,7 @@ type KeyColumn struct {
 }
 
 func (k *KeyColumn) String() string {
-	return fmt.Sprintf("column:'%s' %s: %s", k.Name, pluralize.NewClient().Pluralize("operator", len(k.Operators), false), strings.Join(k.Operators, ","))
+	return fmt.Sprintf("column:'%s' %s: %s", k.Name, pluralizeClient().Pluralize("operator", len(k.Operators), false), strings.Join(k.Operators, ","))
 }
 
 // ToProtobuf converts the KeyColumn to a protobuf object.

--- a/plugin/key_column_bench_test.go
+++ b/plugin/key_column_bench_test.go
@@ -1,0 +1,11 @@
+package plugin
+
+import "testing"
+
+func BenchmarkKeyColumnString(b *testing.B) {
+	k := &KeyColumn{Name: "id", Operators: []string{"=", "!="}}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = k.String()
+	}
+}

--- a/plugin/list_config.go
+++ b/plugin/list_config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/gertd/go-pluralize"
 	"github.com/turbot/steampipe-plugin-sdk/v5/rate_limiter"
 )
 
@@ -132,7 +131,7 @@ func (c *ListConfig) Validate(table *Table) []string {
 				table.Name,
 				listHydrateName,
 				numDeps,
-				pluralize.NewClient().Pluralize("dependency", numDeps, false)))
+				pluralizeClient().Pluralize("dependency", numDeps, false)))
 			break
 		}
 	}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/danwakefield/fnmatch"
 	"github.com/fsnotify/fsnotify"
-	"github.com/gertd/go-pluralize"
 	"github.com/hashicorp/go-hclog"
 	"github.com/turbot/go-kit/helpers"
 	connectionmanager "github.com/turbot/steampipe-plugin-sdk/v5/connection"
@@ -633,7 +632,7 @@ func logValidationWarning(connection *Connection, warnings []string) {
 	log.Printf("[WARN] connection %s, has %d table validation %s",
 		connection.Name,
 		count,
-		pluralize.NewClient().Pluralize("warning", count, false))
+		pluralizeClient().Pluralize("warning", count, false))
 
 	for _, w := range warnings {
 		log.Printf("[WARN] %s", w)

--- a/plugin/plugin_connection_config.go
+++ b/plugin/plugin_connection_config.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/gertd/go-pluralize"
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
@@ -105,7 +104,7 @@ func (p *Plugin) upsertConnections(configs []*proto.ConnectionConfig, updateData
 
 	log.Printf("[INFO] upsertConnections adding %d connection %s",
 		len(configs),
-		pluralize.NewClient().Pluralize("connection", len(configs), false))
+		pluralizeClient().Pluralize("connection", len(configs), false))
 
 	for _, config := range configs {
 		if config.IsAggregator() {

--- a/plugin/plugin_grpc.go
+++ b/plugin/plugin_grpc.go
@@ -10,7 +10,6 @@ import (
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/semaphore"
 
-	"github.com/gertd/go-pluralize"
 	"github.com/hashicorp/go-hclog"
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/v5/error_helpers"
@@ -333,14 +332,14 @@ func (p *Plugin) logExecuteConnections(req *proto.ExecuteRequest, connections ma
 		if len(connections) == len(req.ExecuteConnectionData) {
 			log.Printf("[INFO] Executing for %d %s: %s (%s)",
 				len(connections),
-				pluralize.NewClient().Pluralize("connection", len(connections), false),
+				pluralizeClient().Pluralize("connection", len(connections), false),
 				strings.Join(maps.Keys(connections), ", "),
 				req.CallId)
 		} else {
 			log.Printf("[INFO] Executing for %d of %d %s: %s (%s)",
 				len(connections),
 				len(req.ExecuteConnectionData),
-				pluralize.NewClient().Pluralize("connection", len(req.ExecuteConnectionData), false),
+				pluralizeClient().Pluralize("connection", len(req.ExecuteConnectionData), false),
 				strings.Join(maps.Keys(connections), ", "),
 				req.CallId)
 		}

--- a/plugin/plugin_rate_limiter.go
+++ b/plugin/plugin_rate_limiter.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"github.com/gertd/go-pluralize"
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/v5/rate_limiter"
 	"golang.org/x/exp/maps"
@@ -35,7 +34,7 @@ func (p *Plugin) getHydrateCallRateLimiter(hydrateCallTags map[string]string, qu
 
 	log.Printf("[INFO] found %d matching %s",
 		len(limiters),
-		pluralize.NewClient().Pluralize("limiter", len(limiters), false))
+		pluralizeClient().Pluralize("limiter", len(limiters), false))
 
 	// finally package them into a multi-limiter
 	res = rate_limiter.NewMultiLimiter(limiters, rateLimiterScopeValues)

--- a/plugin/plugin_validate.go
+++ b/plugin/plugin_validate.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"fmt"
-	"github.com/gertd/go-pluralize"
 	"github.com/turbot/go-kit/helpers"
 	"log"
 )
@@ -37,9 +36,9 @@ func (p *Plugin) validate(tableMap map[string]*Table) (validationWarnings, valid
 
 	log.Printf("[INFO] plugin validation result: %d %s %d %s",
 		len(validationWarnings),
-		pluralize.NewClient().Pluralize("warning", len(validationWarnings), false),
+		pluralizeClient().Pluralize("warning", len(validationWarnings), false),
 		len(validationErrors),
-		pluralize.NewClient().Pluralize("error", len(validationErrors), false))
+		pluralizeClient().Pluralize("error", len(validationErrors), false))
 
 	// dedupe the errors and warnins
 	validationWarnings = helpers.SortedMapKeys(helpers.SliceToLookup(validationWarnings))

--- a/plugin/pluralize_client.go
+++ b/plugin/pluralize_client.go
@@ -1,0 +1,9 @@
+package plugin
+
+import (
+	"sync"
+
+	"github.com/gertd/go-pluralize"
+)
+
+var pluralizeClient = sync.OnceValue(pluralize.NewClient)

--- a/plugin/table_fetch.go
+++ b/plugin/table_fetch.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/gertd/go-pluralize"
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
@@ -94,7 +93,7 @@ func (t *Table) buildMissingKeyColumnError(operation string, unsatisfiedColumns 
 		operation,
 		t.Name,
 		len(unsatisfiedColumns),
-		pluralize.NewClient().Pluralize("qual", len(unsatisfiedColumns), false),
+		pluralizeClient().Pluralize("qual", len(unsatisfiedColumns), false),
 		unsatisfied,
 	))
 	return err
@@ -417,7 +416,7 @@ func (t *Table) getListCallQualValueList(queryData *QueryData) *quals.Qual {
 	if numQualsWithListValues > 0 {
 		log.Printf("[TRACE] %d %s have list values",
 			numQualsWithListValues,
-			pluralize.NewClient().Pluralize("qual", numQualsWithListValues, false))
+			pluralizeClient().Pluralize("qual", numQualsWithListValues, false))
 
 		// if we have more than one qual with list values, extract the required ones
 		// if more than one of these is required, this is an error

--- a/query_cache/pluralize_client.go
+++ b/query_cache/pluralize_client.go
@@ -1,0 +1,9 @@
+package query_cache
+
+import (
+	"sync"
+
+	"github.com/gertd/go-pluralize"
+)
+
+var pluralizeClient = sync.OnceValue(pluralize.NewClient)

--- a/query_cache/query_cache.go
+++ b/query_cache/query_cache.go
@@ -14,7 +14,6 @@ import (
 	"github.com/eko/gocache/lib/v4/cache"
 	"github.com/eko/gocache/lib/v4/store"
 	bigcache_store "github.com/eko/gocache/store/bigcache/v4"
-	"github.com/gertd/go-pluralize"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc"
 	sdkproto "github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/telemetry"
@@ -338,7 +337,7 @@ func (c *QueryCache) AbortSet(ctx context.Context, callId string, err error) {
 	log.Printf("[WARN] QueryCache AbortSet - aborting request  with error %s (%d %s) (%s)",
 		err.Error(),
 		len(req.subscribers),
-		pluralize.NewClient().Pluralize("subscriber", len(req.subscribers), false),
+		pluralizeClient().Pluralize("subscriber", len(req.subscribers), false),
 		req.CallId)
 
 	req.state = requestError

--- a/query_cache/set_request.go
+++ b/query_cache/set_request.go
@@ -3,7 +3,6 @@ package query_cache
 import (
 	"context"
 	"fmt"
-	"github.com/gertd/go-pluralize"
 	"github.com/sethvargo/go-retry"
 	sdkproto "github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"log"
@@ -222,7 +221,7 @@ func (req *setRequest) readPageFromCacheWithRetries(ctx context.Context, pageIdx
 	log.Printf("[INFO] getRowsSince read page %d after %d %s  - key %s (%s)",
 		pageIdx,
 		retries,
-		pluralize.NewClient().Pluralize("retry", retries, false),
+		pluralizeClient().Pluralize("retry", retries, false),
 		pageKey,
 		req.CallId)
 


### PR DESCRIPTION
## Summary

- `pluralize.NewClient()` registers ~80 pluralization + ~80 singularization rules, each calling `regexp.MustCompile`. The `Client` is read-only after init and safe for concurrent use, so a per-call instance is wasteful.
- Profiling a real plugin (`steampipe-plugin-synapps`) under production-shape workload showed this path accounted for **~30% of cumulative heap allocations** (1.47 GB out of 4.74 GB during a 3,200-row burst).
- Replaces all 16 `pluralize.NewClient()` callsites in `plugin/` and `query_cache/` with a package-level singleton backed by `sync.OnceValue` (Go 1.21+; SDK already requires 1.26).

## Benchmark

`BenchmarkKeyColumnString` on `plugin/key_column.go`:

| | allocs/op | B/op | ns/op |
|---|---:|---:|---:|
| Before | 2317 | 343,496 | 207,166 |
| After  | 16   | 476     | 11,462  |

~145× fewer allocations, ~720× less heap pressure per call, ~18× faster.

## Test plan

- [x] `go build ./...`
- [x] `go test ./plugin/... ./query_cache/...`
- [x] `grep -rn "pluralize.NewClient" plugin/ query_cache/` shows only the two new singleton files
- [x] `go test -bench=BenchmarkKeyColumnString -benchmem ./plugin/`