### PR TITLE
v6: Fix three races in in-process `Execute` that drop or corrupt scan results

### DIFF
--- a/anywhere/local_plugin_stream.go
+++ b/anywhere/local_plugin_stream.go
@@ -2,6 +2,7 @@ package anywhere
 
 import (
 	"context"
+	"sync"
 
 	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
 )
@@ -12,7 +13,10 @@ const localPluginStreamBuffer = 1024
 type LocalPluginStream struct {
 	ctx  context.Context
 	rows chan *proto.ExecuteResponse
-	err  error
+	// mu guards err, which is written by Error and read/cleared by Recv,
+	// potentially from different goroutines.
+	mu  sync.Mutex
+	err error
 	// this channel is closed whenever the local plugin stream receives its first row or error
 	// this is to make sure either it waits for the first row or error before returning from Recv
 	ready chan struct{}
@@ -52,12 +56,23 @@ func (s *LocalPluginStream) Send(r *proto.ExecuteResponse) error {
 	}
 }
 
+// takeErr returns any pending error and clears it, under s.mu.
+func (s *LocalPluginStream) takeErr() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	err := s.err
+	s.err = nil
+	return err
+}
+
 func (s *LocalPluginStream) Error(err error) {
 	select {
 	case <-s.done:
 		return
 	default:
+		s.mu.Lock()
 		s.err = err
+		s.mu.Unlock()
 		// Ensure ready channel is closed
 		select {
 		case <-s.ready:
@@ -71,39 +86,50 @@ func (s *LocalPluginStream) Error(err error) {
 
 func (s *LocalPluginStream) Recv() (*proto.ExecuteResponse, error) {
 	// Check for error first
-	if err := s.err; err != nil {
-		s.err = nil
+	if err := s.takeErr(); err != nil {
 		return nil, err
 	}
 
-	// Check if done
+	// Check if done. Error() sets s.err before close(s.done), so observing the
+	// done close happens-after that write: a done with a pending error must return
+	// the error, not a clean (nil, nil) EOF.
 	select {
 	case <-s.done:
+		if err := s.takeErr(); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	case <-s.ctx.Done():
 		return nil, s.ctx.Err()
 	default:
 	}
 
-	// Wait for ready or context cancellation
+	// Wait for ready or context cancellation. ready and done can be closed at the
+	// same instant (Error() closes both), so a done win here must likewise surface
+	// any pending error rather than a clean EOF.
 	select {
 	case <-s.ready:
 		// ready channel closed, proceed
 	case <-s.ctx.Done():
 		return nil, s.ctx.Err()
 	case <-s.done:
+		if err := s.takeErr(); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}
 
 	// Check for error again after ready
-	if err := s.err; err != nil {
-		s.err = nil
+	if err := s.takeErr(); err != nil {
 		return nil, err
 	}
 
 	// Try to get a row
 	select {
 	case <-s.done:
+		if err := s.takeErr(); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	case <-s.ctx.Done():
 		return nil, s.ctx.Err()

--- a/plugin/hydrate_call.go
+++ b/plugin/hydrate_call.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 	"slices"
-	"sync/atomic"
 	"time"
 
 	"github.com/turbot/steampipe-plugin-sdk/v6/rate_limiter"
@@ -99,7 +98,7 @@ func (h *hydrateCall) start(ctx context.Context, r *rowData, d *QueryData) time.
 	// tell the rowData to wait for this call to complete
 	r.wg.Add(1)
 	// update the hydrate count
-	atomic.AddInt64(&d.queryStatus.hydrateCalls, 1)
+	d.queryStatus.hydrateCalls.Add(1)
 
 	// call callHydrate async, ignoring return values
 	go func() {

--- a/plugin/hydrate_calls_race_test.go
+++ b/plugin/hydrate_calls_race_test.go
@@ -1,0 +1,145 @@
+package plugin_test
+
+// Self-contained reproduction of a data race on the per-query stats counter
+// QueryData.queryStatus.hydrateCalls, observable inside a *single* Execute.
+//
+// The race:
+//
+//   - WRITERS: every row schedules its hydrate calls via hydrateCall.start,
+//     which bumps queryStatus.hydrateCalls; buildRowsAsync fans these out
+//     across many concurrent per-row goroutines.
+//
+//   - READER: the streaming goroutine stamps the running total onto every
+//     outgoing row's metadata (QueryMetadata.HydrateCalls) with a plain read.
+//
+// An unsynchronised writer and reader on the same counter = a data race,
+// flagged by `go test -race`. It is NOT a cross-Execute or shared-server
+// problem: a single Execute over a hydrate-backed table with enough in-flight
+// rows is sufficient. The window only opens when streaming overlaps the per-row
+// hydrate scheduling, so it needs a non-trivial row count — a handful of rows
+// drains before the goroutines overlap and passes clean.
+//
+// Impact is observability-only: the counter feeds QueryMetadata.HydrateCalls
+// (a stats field). Row payloads are unaffected — all rows still stream. The
+// fix types the queryStatus counters as atomic.Int64 and routes every access
+// through Load/Add/Store, so a plain (racy) access becomes a compile error.
+//
+// Run:  go test -race -run TestHydrateCallsCounterRace ./plugin/
+//
+// raceRows is sized well past the streaming/hydrate overlap threshold so the
+// window reliably opens; the same table at ~5 rows passes clean under -race.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/turbot/steampipe-plugin-sdk/v6/anywhere"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
+)
+
+const (
+	raceConnection = "race_fixture"
+	raceTable      = "race_widget"
+	raceRows       = 2000
+)
+
+type raceWidget struct {
+	ID int
+}
+
+// listRaceWidgets streams raceRows items from the List call.
+func listRaceWidgets(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (any, error) {
+	for i := 0; i < raceRows; i++ {
+		d.StreamListItem(ctx, raceWidget{ID: i})
+	}
+	return nil, nil
+}
+
+// raceWidgetSize is a per-row hydrate function: one hydrate call per streamed
+// row, so every row contributes a concurrent atomic increment to hydrateCalls.
+func raceWidgetSize(_ context.Context, _ *plugin.QueryData, h *plugin.HydrateData) (any, error) {
+	return h.Item.(raceWidget).ID * 10, nil
+}
+
+// raceFixturePlugin is a trivial in-process plugin with one hydrate-backed
+// table — no cloud provider, no external calls.
+func raceFixturePlugin(_ context.Context) *plugin.Plugin {
+	return &plugin.Plugin{
+		Name: "steampipe-plugin-race-fixture",
+		TableMap: map[string]*plugin.Table{
+			raceTable: {
+				Name: raceTable,
+				List: &plugin.ListConfig{Hydrate: listRaceWidgets},
+				Columns: []*plugin.Column{
+					{Name: "id", Type: proto.ColumnType_INT, Transform: transform.FromField("ID")},
+					// `size` resolves from its own hydrate function: one call per row
+					{Name: "size", Type: proto.ColumnType_INT, Hydrate: raceWidgetSize, Transform: transform.FromValue()},
+				},
+			},
+		},
+	}
+}
+
+// TestHydrateCallsCounterRace drives one Execute over a hydrate-backed table
+// and drains every row. There is no concurrency at the test layer: a single
+// Execute is enough. Under `-race` the detector reports a data race between the
+// hydrate-call writers and the streaming-goroutine reader on
+// queryStatus.hydrateCalls.
+func TestHydrateCallsCounterRace(t *testing.T) {
+	server := plugin.Server(&plugin.ServeOpts{PluginFunc: raceFixturePlugin})
+
+	// Disable the query cache: not required for the race, but keeps the run a
+	// pure provider-side scan with deterministic stats.
+	server.SetCacheOptions(&proto.SetCacheOptionsRequest{Enabled: false, MaxSizeMb: 32})
+
+	cfg := &proto.ConnectionConfig{
+		Connection:      raceConnection,
+		Plugin:          "steampipe-plugin-race-fixture",
+		PluginShortName: "race-fixture",
+		PluginInstance:  "steampipe-plugin-race-fixture",
+	}
+	if _, err := server.SetAllConnectionConfigs(&proto.SetAllConnectionConfigsRequest{
+		Configs:        []*proto.ConnectionConfig{cfg},
+		MaxCacheSizeMb: 32,
+	}); err != nil {
+		t.Fatalf("SetAllConnectionConfigs: %v", err)
+	}
+
+	ctx := context.Background()
+	stream := anywhere.NewLocalPluginStream(ctx)
+	qc := proto.NewQueryContext([]string{"id", "size"}, nil, -1, nil)
+	ecd := &proto.ExecuteConnectionData{CacheEnabled: false}
+	req := &proto.ExecuteRequest{
+		Table:                 raceTable,
+		QueryContext:          qc,
+		CallId:                grpc.BuildCallId(),
+		Connection:            raceConnection,
+		ExecuteConnectionData: map[string]*proto.ExecuteConnectionData{raceConnection: ecd},
+		CacheEnabled:          false,
+	}
+
+	server.CallExecuteAsync(req, stream)
+
+	var rows int
+	for {
+		item, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("stream.Recv after %d rows: %v", rows, err)
+		}
+		if item == nil {
+			break
+		}
+		if item.Row != nil {
+			rows++
+		}
+	}
+
+	// Payloads are unaffected by the race — every row still streams. This
+	// assertion documents that the race is stats-only, not data loss.
+	if rows != raceRows {
+		t.Fatalf("streamed %d rows, want %d", rows, raceRows)
+	}
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/danwakefield/fnmatch"
@@ -469,7 +468,7 @@ func (p *Plugin) executeForConnection(streamContext context.Context, req *proto.
 		streamCachedRowFunc := func(row *proto.Row) {
 			// if row is not nil (indicating completion), increment cachedRowsFetched
 			if row != nil {
-				atomic.AddInt64(&queryData.queryStatus.cachedRowsFetched, 1)
+				queryData.queryStatus.cachedRowsFetched.Add(1)
 			}
 			streamUncachedRowFunc(row)
 		}

--- a/plugin/plugin_grpc.go
+++ b/plugin/plugin_grpc.go
@@ -322,6 +322,20 @@ func (p *Plugin) execute(req *proto.ExecuteRequest, stream row_stream.Sender) (e
 	close(outputChan)
 	close(errorChan)
 
+	// Drain any errors the select loop did not consume. errorChan is buffered and
+	// every connection goroutine writes its error before signalling completion
+	// (outputWg.Done), so by the time the completion nil reached outputChan all
+	// errors were already buffered. Both channels can be ready at once, so the
+	// select above may have taken the completion nil and broken out before reading
+	// a pending error — without this drain that error is silently lost and Execute
+	// returns nil for a failed scan.
+	for err := range errorChan {
+		if !error_helpers.IsContextCancelledError(err) {
+			log.Printf("[WARN] error channel received (drain) %s", err.Error())
+		}
+		errors = append(errors, err)
+	}
+
 	return helpers.CombineErrors(errors...)
 }
 

--- a/plugin/plugin_grpc.go
+++ b/plugin/plugin_grpc.go
@@ -284,24 +284,13 @@ func (p *Plugin) execute(req *proto.ExecuteRequest, stream row_stream.Sender) (e
 	for !complete {
 		select {
 		case row := <-outputChan:
-			// nil row means that one connection is done streaming
+			// nil row means that one connection is done streaming. Just exit the
+			// loop here; the terminal nil sentinel for local streams is sent below,
+			// after errorChan is drained, so it can be suppressed when the scan
+			// errored (see the nil-send race note there).
 			if row == nil {
 				log.Printf("[INFO] empty row on output channel - we are done ")
 				complete = true
-
-				// if the stream is a grpc stream, no need to send a nil item - break out
-				if _, ok := stream.(proto.WrapperPlugin_ExecuteServer); ok {
-					log.Printf("[INFO] return without streaming nil row as this is GRPC stream")
-					break
-				}
-				// fall through to send empty row (required if using local stream)
-				log.Printf("[INFO] Sending nil row")
-				if err := stream.Send(row); err != nil {
-					// ignore context cancellation - they will get picked up further downstream
-					if !error_helpers.IsContextCancelledError(err) {
-						errors = append(errors, grpc.HandleGrpcError(err, p.Name, "stream.Send"))
-					}
-				}
 				break
 			}
 			if err := stream.Send(row); err != nil {
@@ -334,6 +323,19 @@ func (p *Plugin) execute(req *proto.ExecuteRequest, stream row_stream.Sender) (e
 			log.Printf("[WARN] error channel received (drain) %s", err.Error())
 		}
 		errors = append(errors, err)
+	}
+
+	// Terminal nil sentinel for a local stream (a grpc stream needs none). Send it
+	// only on a clean scan: on error the executeFunc-return path delivers the error
+	// via stream.Error after this Execute returns, and a nil sentinel here would
+	// reach the receiver first and be read as a clean EOF — masking the failure.
+	// Gating on the fully drained errors makes the success and failure terminals
+	// mutually exclusive.
+	if _, ok := stream.(proto.WrapperPlugin_ExecuteServer); !ok && len(errors) == 0 {
+		log.Printf("[INFO] Sending nil row (local stream completion)")
+		if err := stream.Send(nil); err != nil && !error_helpers.IsContextCancelledError(err) {
+			errors = append(errors, grpc.HandleGrpcError(err, p.Name, "stream.Send"))
+		}
 	}
 
 	return helpers.CombineErrors(errors...)

--- a/plugin/query_data.go
+++ b/plugin/query_data.go
@@ -300,7 +300,7 @@ func (d *QueryData) RowsRemaining(ctx context.Context) int64 {
 	if IsCancelled(ctx) {
 		return 0
 	}
-	rowsRemaining := d.queryStatus.rowsRequired - d.queryStatus.rowsStreamed
+	rowsRemaining := d.queryStatus.rowsRequired - d.queryStatus.rowsStreamed.Load()
 	return rowsRemaining
 }
 
@@ -650,7 +650,7 @@ func (d *QueryData) streamLeafListItem(ctx context.Context, items ...interface{}
 			continue
 		}
 		// increment the stream count
-		d.queryStatus.rowsStreamed++
+		d.queryStatus.rowsStreamed.Add(1)
 
 		// create rowData, passing matrixItem from context
 		rd := newRowData(d, item)
@@ -669,7 +669,7 @@ func (d *QueryData) streamLeafListItem(ctx context.Context, items ...interface{}
 
 // if a free memory interval has been set, check if we have reached it
 func (d *QueryData) shouldFreeMemory() bool {
-	return d.freeMemInterval != 0 && d.queryStatus.rowsStreamed%d.freeMemInterval == 0
+	return d.freeMemInterval != 0 && d.queryStatus.rowsStreamed.Load()%d.freeMemInterval == 0
 }
 
 // called when all items have been fetched - close the item chan
@@ -828,10 +828,10 @@ func (d *QueryData) streamRow(row *proto.Row) {
 	resp := &proto.ExecuteResponse{
 		Row: row,
 		Metadata: &proto.QueryMetadata{
-			HydrateCalls: d.queryStatus.hydrateCalls,
+			HydrateCalls: d.queryStatus.hydrateCalls.Load(),
 			// only 1 of these will be non zero
-			RowsFetched: d.queryStatus.rowsStreamed + d.queryStatus.cachedRowsFetched,
-			CacheHit:    d.queryStatus.cachedRowsFetched > 0,
+			RowsFetched: d.queryStatus.rowsStreamed.Load() + d.queryStatus.cachedRowsFetched.Load(),
+			CacheHit:    d.queryStatus.cachedRowsFetched.Load() > 0,
 		},
 		Connection: d.Connection.Name,
 	}

--- a/plugin/query_status.go
+++ b/plugin/query_status.go
@@ -3,13 +3,19 @@ package plugin
 import (
 	"context"
 	"math"
+	"sync/atomic"
 )
 
 type queryStatus struct {
-	rowsRequired      int64
-	rowsStreamed      int64
-	hydrateCalls      int64
-	cachedRowsFetched int64
+	rowsRequired int64
+	// counters mutated and read concurrently: the streaming goroutine stamps
+	// running totals onto each row's metadata (QueryData.streamRow) while the
+	// list goroutine and the per-row hydrate goroutines increment them. They are
+	// atomic.Int64 so those accesses never race (a plain field is trivially
+	// read non-atomically by mistake; the type makes that a compile error).
+	rowsStreamed      atomic.Int64
+	hydrateCalls      atomic.Int64
+	cachedRowsFetched atomic.Int64
 	// flag which is true when we have streamed enough rows (or the context is cancelled)
 	StreamingComplete bool
 }
@@ -33,6 +39,6 @@ func (s *queryStatus) RowsRemaining(ctx context.Context) int64 {
 	if IsCancelled(ctx) {
 		return 0
 	}
-	rowsRemaining := s.rowsRequired - s.rowsStreamed
+	rowsRemaining := s.rowsRequired - s.rowsStreamed.Load()
 	return rowsRemaining
 }

--- a/plugin/retry_config.go
+++ b/plugin/retry_config.go
@@ -128,8 +128,8 @@ func (c *RetryConfig) GetListRetryConfig() *RetryConfig {
 	listRetryConfig := &RetryConfig{}
 	if c.ShouldRetryErrorFunc != nil {
 		listRetryConfig.ShouldRetryErrorFunc = func(ctx context.Context, d *QueryData, h *HydrateData, err error) bool {
-			if d.queryStatus.rowsStreamed != 0 {
-				log.Printf("[TRACE] shouldRetryError we have started streaming rows (%d) - return false", d.queryStatus.rowsStreamed)
+			if rowsStreamed := d.queryStatus.rowsStreamed.Load(); rowsStreamed != 0 {
+				log.Printf("[TRACE] shouldRetryError we have started streaming rows (%d) - return false", rowsStreamed)
 				return false
 			}
 			res := c.ShouldRetryErrorFunc(ctx, d, h, err)
@@ -137,8 +137,8 @@ func (c *RetryConfig) GetListRetryConfig() *RetryConfig {
 		}
 	} else if c.ShouldRetryError != nil {
 		listRetryConfig.ShouldRetryErrorFunc = func(ctx context.Context, d *QueryData, h *HydrateData, err error) bool {
-			if d.queryStatus.rowsStreamed != 0 {
-				log.Printf("[TRACE] shouldRetryError we have started streaming rows (%d) - return false", d.queryStatus.rowsStreamed)
+			if rowsStreamed := d.queryStatus.rowsStreamed.Load(); rowsStreamed != 0 {
+				log.Printf("[TRACE] shouldRetryError we have started streaming rows (%d) - return false", rowsStreamed)
 				return false
 			}
 			// call the legacy function

--- a/plugin/table_fetch.go
+++ b/plugin/table_fetch.go
@@ -209,7 +209,7 @@ func (t *Table) doGet(ctx context.Context, queryData *QueryData) (err error) {
 		// NOTE: explicitly set the get hydrate results on rowData
 		rd.set(hydrateKey, rd.item)
 		// set the rowsStreamed to 1
-		queryData.queryStatus.rowsStreamed = 1
+		queryData.queryStatus.rowsStreamed.Store(1)
 		// send the result down the stream
 		queryData.rowDataChan <- rd
 	}


### PR DESCRIPTION
## Context

Hey folks, I'm working on a side project where I'm using the plugin sdk and AWS plugin directly as a Go library. In that harness I've got it running several queries concurrently which might not be the typical usage pattern when run via the Steampipe FDW path.

The first sign that I needed to be cautious is actually the third commit where the hydration metric seemed off. Once I found there was a race in the counter I started paying more attention to anything else off. A day later I found it eating errors for a test I wrote that expected errors to propagate back out. Saw the errors in the hydration logs but not in my test.

The counters was cosmetic and annoying but the error propagation felt worthy enough to raise the issue.

I'm still getting familiar with the code base so I'm hesitant to just throw this out there assuming I'm correct. I'm going to exercise the fix for a time and report back what I see. In the mean time I thought it would be useful to open as a draft PR to share my finding.

## Summary

The in-process execution path (`CallExecuteAsync` + `anywhere.LocalPluginStream`, "steampipe anywhere") has three concurrency bugs. Two of them can **silently drop a failed scan's error**, so a connection that actually errored (e.g. a `ListBuckets` 403) is reported to the caller as a clean, empty result. The third **corrupts per-query stats counters** under `go test -race`.

All three reproduce against a single `Execute` over one table — no shared server, no cross-`Execute` interaction, no cloud provider required.

## Race 1 — fan-in select drops a buffered error (`plugin/plugin_grpc.go`)

Each per-connection goroutine writes its error to the buffered `errorChan` *before* its deferred `outputWg.Done()`. A separate goroutine waits the group, then sends the completion `nil` on `outputChan`. The fan-in select races `<-outputChan` (completion) against `<-errorChan`:

```go
for !complete {
    select {
    case row := <-outputChan:
        if row == nil { complete = true; ... break }  // exits loop
        ...
    case err := <-errorChan:
        errors = append(errors, err)
    }
}
return helpers.CombineErrors(errors...)
```

Because `errorChan` is buffered (`len(connections)`), the error write does not block, so by the time the completion `nil` lands both channels are ready. If the select takes the completion `nil`, the loop exits **without draining the pending error** and `CombineErrors()` returns nil.

**Fix:** drain `errorChan` after the loop. Every connection writes its error before signalling completion, so once the completion `nil` has arrived all errors are already buffered and can be collected deterministically.

## Race 2 — local-stream nil sentinel races `stream.Error` (`plugin/plugin_grpc.go` + `grpc/pluginServer.go`)

For a `LocalPluginStream`, `Execute` sends a `nil` completion sentinel *inside* `executeFunc`, but a scan error is only delivered *after* `Execute` returns, when `CallExecuteAsync` turns the `executeFunc` return value into `stream.Error(err)`. The receiver can read the `nil` sentinel as a clean EOF before `Error` ever fires — masking the failure even after Race 1 is fixed.

**Fix:** move the local-stream `nil` sentinel to after `errorChan` is drained and send it only when there were no errors. Success (nil sentinel) and failure (`stream.Error`) terminals become mutually exclusive.

## Race 3 — `LocalPluginStream.Recv` done/error race (`anywhere/local_plugin_stream.go`)

`Error()` sets `s.err`, then closes both `ready` and `done`. For an error with no prior rows all three happen at once, so `Recv` can take a `done` branch and return `(nil, nil)` — swallowing the error as a clean EOF.

**Fix:** every `done` branch in `Recv` checks `s.err` first and returns it. The `close(s.done)` happens-after the `s.err` write, so the read is safe.

## Race 4 — per-query stats counters read non-atomically (`plugin/query_status.go` + call sites)

`QueryData.streamRow` reads the `queryStatus` counters (`hydrateCalls`, `rowsStreamed`, `cachedRowsFetched`) non-atomically while other goroutines of the *same* `Execute` write them: the streaming goroutine stamps running totals onto each row's metadata while the list goroutine and the per-row hydrate goroutines increment. `go test -race` flags it; a single `Execute` over a hydrate-backed table with a couple thousand rows reproduces reliably.

Note the prior inconsistency: `hydrateCalls` and `cachedRowsFetched` were *written* atomically but *read* plainly, and `rowsStreamed` was plain on both sides.

**Impact is observability-only** — the counters feed `QueryMetadata` (`HydrateCalls`, `RowsFetched`, `CacheHit`). Row payloads are unaffected.

**Fix:** make the three counters `atomic.Int64` and route every access through `Load`/`Add`/`Store`. Typing the fields atomic (rather than scattering `atomic.LoadInt64` at read sites) removes the whole class — a plain read of an `atomic.Int64` is a compile error. `rowsRequired` is write-once at construction, left plain.

## Reproduction

A self-contained `-race` test using only public SDK API (no cloud provider) is included for Race 4: it builds a trivial in-process plugin with one hydrate-backed table, runs a single `Execute` over ~2000 rows, and drains every row.

```
go test -race -run TestHydrateCallsCounterRace ./plugin/
```

Fails on the current tree; passes with the fix.

Races 1–3 were found via a downstream harness that drives an in-process plugin against a reachable-but-erroring endpoint (`ListBuckets` 403) and asserts the scope is reported failed; before the fix it was intermittently reported as a clean empty result.

## Commits

- `surface scan errors lost to two execute races` — Race 1 (errorChan drain) + Race 3 (Recv)
- `do not send local-stream nil sentinel on a failed scan` — Race 2
- `make per-query stats counters atomic to fix data race` — Race 4 + `-race` repro test
