### PR TITLE
Reinstate the chaos acceptance tests on the v6 line

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -28,19 +28,16 @@ jobs:
             version: v2.10.1
             args: --timeout=15m --config=.golangci.yml
 
+        # -race is required: the SDK's race regression tests only fail under
+        # the race detector, so without it they assert nothing.
         - name: Run SDK Unit Tests
           run: |
             go clean -testcache
-            go test -timeout 600s ./... -test.v
+            go test -race -timeout 900s ./... -test.v
 
   buildChaosPlugin:
     name: Run chaos acceptance tests
     needs: sdkUnitTests
-    # Skip on v6.x — the steampipe CLI still imports /v5, so the
-    # `go mod edit -replace .../v5=...` step below can't substitute a /v6
-    # SDK into it. Re-enable once steampipe is migrated to v6 (or the
-    # workflow is updated to swap both module paths).
-    if: github.base_ref != 'v6.x' && github.head_ref != 'v6.x'
     runs-on: ubuntu-latest
     steps:
 
@@ -52,27 +49,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: sdk
 
-      - name: Get latest Steampipe release tag
-        id: steampipe-release
-        run: |
-          tag=$(curl -s https://api.github.com/repos/turbot/steampipe/releases/latest | jq -r '.tag_name')
-          echo "tag=$tag" >> $GITHUB_OUTPUT
-
+      # develop, not the latest release: the released steampipe still requires
+      # steampipe-plugin-sdk/v5, so there is no /v6 requirement to replace and
+      # the SDK under test would be silently left out of the build. Pin back to
+      # a release tag once a steampipe release ships on /v6 — tracking develop
+      # means an unrelated break there turns this job red.
       - name: Checkout Steampipe
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: turbot/steampipe
-          ref: ${{ steps.steampipe-release.outputs.tag }}
+          ref: develop
           path: steampipe
 
       - name: Update go.mod and build Steampipe
         run: |
           echo "PATH=$PATH:$HOME/build:/home/runner" >> $GITHUB_ENV
           cd /home/runner/work/steampipe-plugin-sdk/steampipe-plugin-sdk/steampipe
-          go mod edit -replace github.com/turbot/steampipe-plugin-sdk/v5=/home/runner/work/steampipe-plugin-sdk/steampipe-plugin-sdk/sdk
+          go mod edit -replace github.com/turbot/steampipe-plugin-sdk/v6=/home/runner/work/steampipe-plugin-sdk/steampipe-plugin-sdk/sdk
           go mod tidy
           go build -o /home/runner/steampipe
 
@@ -91,7 +86,7 @@ jobs:
         run: |
           echo "PATH=$PATH:$HOME/build::/home/runner/work/steampipe-plugin-sdk/steampipe-plugin-sdk/steampipe-plugin-chaos/tests/acceptance/lib/bats/libexec" >> $GITHUB_ENV
           cd /home/runner/work/steampipe-plugin-sdk/steampipe-plugin-sdk/steampipe-plugin-chaos/
-          go mod edit -replace github.com/turbot/steampipe-plugin-sdk/v5=/home/runner/work/steampipe-plugin-sdk/steampipe-plugin-sdk/sdk
+          go mod edit -replace github.com/turbot/steampipe-plugin-sdk/v6=/home/runner/work/steampipe-plugin-sdk/steampipe-plugin-sdk/sdk
           go mod tidy
           make
 


### PR DESCRIPTION
## What this does

Re-enables the chaos acceptance job on the v6 line, and makes it test what it claims to test.

## Why

The job was switched off on the v6 line by `if: github.base_ref != 'v6.x' && github.head_ref != 'v6.x'`. That is a branch-name test standing in for a module-path condition. Once `develop`'s module path becomes `/v6`, a PR into `develop` no longer matches `'v6.x'`, so the job runs against a `/v6` SDK and dies at `go mod tidy` — the replace directive names `/v5`. Every open PR would have gone red at once.

Three further problems came out of fixing it:

**The job has never tested a fork pull request's code.** The SDK checkout set `repository` to the head repo but no `ref`. `actions/checkout` only defaults to the event's ref when checking out the repository that triggered the run; for any other repository it uses that repository's default branch. Both forks with open PRs here default to `develop` at `module github.com/turbot/steampipe-plugin-sdk/v5`, so a green "Run chaos acceptance tests" on a fork PR exercised the fork's default branch, not the change under review. That override has been in place since 2023.

Dropping the `repository` override restores the default behaviour, which resolves to the pull request's merge ref in the base repository — correct for fork and same-repo pull requests alike, and the same tree the unit test job builds.

**The chaos half of the substitution had no effect.** `turbot/steampipe-plugin-chaos` moved to `/v6 v6.0.0`, so `go mod edit -replace .../v5=<sdk>` matched nothing — a replace whose left side is not required is silently ignored rather than being an error, and the line simply sits in `go.mod` doing nothing. The plugin was being built against the published SDK rather than the branch under test. Both replace directives now name `/v6`.

**The unit tests were not running under the race detector.** The SDK's race regression tests only fail with `-race`; `TestConnectionConfig_Race` makes no assertions of its own, so without the flag it asserts nothing. Added, with the timeout raised 600s → 900s to absorb the slowdown.

## The steampipe checkout

Pointed at `develop` rather than the latest release, because the released steampipe still requires `steampipe-plugin-sdk/v5` — there is no `/v6` requirement for the replace to substitute into. This is a stopgap and the comment in the file says so: the checkout was deliberately moved off `develop` once before, when a broken OpenTelemetry transitive dependency there failed the job for reasons unrelated to the SDK under test. It should be pinned back to a release tag as soon as a steampipe release ships on `/v6`.

That dependency problem is currently clear — `go.opentelemetry.io/otel/sdk` and `otel/sdk/metric` both resolve at v1.43.0, so the sub-packages removed at v1.40.0 are back in range.

## Verification

- `go build ./...` and `go test -race ./...` green on this tree.
- steampipe `develop` and `turbot/steampipe-plugin-chaos` both `go mod tidy` and build clean with this checkout substituted in as `/v6`.
- This PR's own run of the reinstated job is the remaining proof.
